### PR TITLE
feat: #4: Add documentation structure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+Closes #
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] Unit tests pass (`task test`)
+- [ ] Pre-commit hooks pass (`task lint`)
+- [ ] Manually tested in Simulator
+
+## Screenshots
+
+<!-- If UI changes, add before/after screenshots -->

--- a/AGENT.md
+++ b/AGENT.md
@@ -80,8 +80,10 @@ task ci          # Full CI check
 
 - [Architecture](docs/ARCHITECTURE.md) - System design
 - [Runbook](docs/RUNBOOK.md) - Procedures
+- [Status](docs/STATUS.md) - Project status
+- [Changelog](CHANGELOG.md) - Release history
 - [GitHub Project](https://github.com/users/benniemosher/projects/2) - Sprint board
-- [Issues](https://github.com/benniemosher/renewed/issues) - Tickets
+- [Issues](https://github.com/Mosher-Labs/renewed/issues) - Tickets
 
 ---
 **Reminder:** Be concise. Save tokens. Build with purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project uses [Semantic Versioning](https://semver.org/) and releases are managed automatically via [semantic-release](https://github.com/ietf-tools/semver-action).
+
+## [v0.2.0]
+
+### Added
+
+- Documentation structure: STATUS.md, CHANGELOG.md, PR template (#4)
+
+## [v0.1.0]
+
+### Added
+
+- Taskfile with bootstrap, build, test, lint, ci, and clean tasks (#3)
+- GitHub Actions CI/CD: pre-commit and semantic release workflows (#3)
+
+### Fixed
+
+- Release workflow secret propagation after repo transfer to Mosher-Labs (#34)
+
+## [v0.0.2]
+
+### Added
+
+- Xcode project scaffold with xcodegen (#2)
+- iOS app target and WidgetKit extension target
+- SwiftData model stubs and directory structure
+- App Group and CloudKit entitlements
+
+## [v0.0.1]
+
+### Added
+
+- Initial repository setup (#1)
+- AGENT.md, ARCHITECTURE.md, RUNBOOK.md documentation
+- README with quick start guide
+- MIT license
+
+[v0.2.0]: https://github.com/Mosher-Labs/renewed/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/Mosher-Labs/renewed/compare/v0.0.2...v0.1.0
+[v0.0.2]: https://github.com/Mosher-Labs/renewed/compare/v0.0.1...v0.0.2
+[v0.0.1]: https://github.com/Mosher-Labs/renewed/commits/v0.0.1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,3 +195,5 @@ All diagrams render in GitHub markdown. Keep them simple and focused.
 
 - [AGENT.md](/AGENT.md) - Agent guide
 - [RUNBOOK.md](RUNBOOK.md) - Procedures
+- [STATUS.md](STATUS.md) - Project status
+- [CHANGELOG.md](/CHANGELOG.md) - Release history

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -155,4 +155,6 @@ xcrun simctl erase all
 
 - [AGENT.md](/AGENT.md) - Agent guide
 - [ARCHITECTURE.md](ARCHITECTURE.md) - System design
+- [STATUS.md](STATUS.md) - Project status
+- [CHANGELOG.md](/CHANGELOG.md) - Release history
 - [GitHub Project](https://github.com/users/benniemosher/projects/2) - Sprint board

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,36 @@
+# Renewed - Project Status
+
+## Current Sprint: Sprint 1 - Foundation
+
+**Goal:** Establish project infrastructure, CI/CD, and documentation.
+
+### Completed
+
+- [x] #1 - Project scaffolding (Xcode project, xcodegen, directory structure)
+- [x] #3 - Taskfile & pre-commit setup
+- [x] #4 - Documentation structure
+
+### In Progress
+
+_None_
+
+### Upcoming
+
+- See [GitHub Project Board](https://github.com/users/benniemosher/projects/2) for full backlog
+
+## Architecture Status
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| iOS App Shell | Scaffolded | Entry point, basic structure |
+| SwiftData Models | Not started | Tracker model planned |
+| Widget Extension | Scaffolded | Target configured |
+| CloudKit Sync | Not started | SwiftData handles this |
+| CI/CD | Active | Pre-commit + semantic release |
+
+## Links
+
+- [AGENT.md](/AGENT.md) - AI developer guide
+- [ARCHITECTURE.md](ARCHITECTURE.md) - System design
+- [RUNBOOK.md](RUNBOOK.md) - Procedures
+- [GitHub Project](https://github.com/users/benniemosher/projects/2) - Sprint board


### PR DESCRIPTION
## Summary

- Create docs/STATUS.md for project status tracking
- Create CHANGELOG.md with full release history (v0.0.1 through v0.2.0)
- Create .github/PULL_REQUEST_TEMPLATE.md
- Update cross-links across all docs (AGENT.md, ARCHITECTURE.md, RUNBOOK.md)
- Fix repo URL from benniemosher/renewed to Mosher-Labs/renewed

Closes #4

## Testing

- [x] All doc links reference each other correctly
- [x] AGENT.md is 89 lines (under 200 limit)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)