### PR TITLE
feat: #6: Add Tracker SwiftData model

### DIFF
--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -10,7 +10,10 @@
 		1AF5FF2CEF690D00642C3A37 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E5DD9CF3AA88B8E5AB2620 /* ContentView.swift */; };
 		3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */; };
 		5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */; };
+		61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411283F45317AA62F5D3BE1B /* TrackerTests.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
+		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
+		A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
 		C0F5E123488761034E91473B /* RenewedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */; };
 		FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */; };
 /* End PBXBuildFile section */
@@ -29,11 +32,14 @@
 		06DBE82BC759C230F1737AAA /* RenewedTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RenewedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F93ADC8867894D16B0BB5CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerListView.swift; sourceTree = "<group>"; };
+		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
 		5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RenewedWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidget.swift; sourceTree = "<group>"; };
+		89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCategory.swift; sourceTree = "<group>"; };
 		8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedApp.swift; sourceTree = "<group>"; };
 		98E5DD9CF3AA88B8E5AB2620 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9CFE1C3C24BBDE97583AB65B /* Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracker.swift; sourceTree = "<group>"; };
 		A4DC09C6AA7D0BC666AEF25C /* Renewed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Renewed.entitlements; sourceTree = "<group>"; };
 		AA7C0BD36DBDA2FAFD62D4C0 /* Renewed.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Renewed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedTests.swift; sourceTree = "<group>"; };
@@ -52,6 +58,7 @@
 			isa = PBXGroup;
 			children = (
 				C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */,
+				411283F45317AA62F5D3BE1B /* TrackerTests.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -61,9 +68,19 @@
 			children = (
 				8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */,
 				DD01D6B839D6E24079587289 /* Config */,
+				4EB4CAB4DE016C09A69F313A /* Models */,
 				077C726CDA976CAC133C651E /* Views */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		4EB4CAB4DE016C09A69F313A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9CFE1C3C24BBDE97583AB65B /* Tracker.swift */,
+				89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		73F8723E515CD0BD6389788E = {
@@ -232,6 +249,8 @@
 			files = (
 				1AF5FF2CEF690D00642C3A37 /* ContentView.swift in Sources */,
 				FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */,
+				9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */,
+				A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */,
 				5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -241,6 +260,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0F5E123488761034E91473B /* RenewedTests.swift in Sources */,
+				61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Models/Tracker.swift
+++ b/Sources/Models/Tracker.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Tracker {
+  var id: UUID
+  var title: String
+  var startDate: Date
+  var category: TrackerCategory
+  var iconName: String
+  var color: String
+  var createdAt: Date
+  var updatedAt: Date
+
+  init(
+    id: UUID = UUID(),
+    title: String,
+    startDate: Date,
+    category: TrackerCategory,
+    iconName: String,
+    color: String,
+    createdAt: Date = Date(),
+    updatedAt: Date = Date()
+  ) {
+    precondition(!title.isEmpty, "Title must not be empty")
+    precondition(startDate <= Date(), "Start date must not be in the future")
+
+    self.id = id
+    self.title = title
+    self.startDate = startDate
+    self.category = category
+    self.iconName = iconName
+    self.color = color
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}

--- a/Sources/Models/TrackerCategory.swift
+++ b/Sources/Models/TrackerCategory.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum TrackerCategory: String, Codable, CaseIterable {
+  case sobriety
+  case freedom
+  case salvation
+  case custom
+}

--- a/Sources/RenewedApp.swift
+++ b/Sources/RenewedApp.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 @main
@@ -6,5 +7,6 @@ struct RenewedApp: App {
     WindowGroup {
       ContentView()
     }
+    .modelContainer(for: Tracker.self)
   }
 }

--- a/Tests/Unit/TrackerTests.swift
+++ b/Tests/Unit/TrackerTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import Renewed
+
+final class TrackerTests: XCTestCase {
+  func testTrackerCreationWithValidData() {
+    let now = Date()
+    let tracker = Tracker(
+      title: "My Recovery",
+      startDate: now,
+      category: .sobriety,
+      iconName: "heart.fill",
+      color: "blue"
+    )
+
+    XCTAssertEqual(tracker.title, "My Recovery")
+    XCTAssertEqual(tracker.startDate, now)
+    XCTAssertEqual(tracker.category, .sobriety)
+    XCTAssertEqual(tracker.iconName, "heart.fill")
+    XCTAssertEqual(tracker.color, "blue")
+  }
+
+  func testTrackerDefaultValues() {
+    let before = Date()
+    let tracker = Tracker(
+      title: "Test",
+      startDate: Date(),
+      category: .freedom,
+      iconName: "star",
+      color: "green"
+    )
+    let after = Date()
+
+    XCTAssertNotEqual(tracker.id, UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+    XCTAssertGreaterThanOrEqual(tracker.createdAt, before)
+    XCTAssertLessThanOrEqual(tracker.createdAt, after)
+    XCTAssertGreaterThanOrEqual(tracker.updatedAt, before)
+    XCTAssertLessThanOrEqual(tracker.updatedAt, after)
+  }
+
+  func testTrackerCategoryAllCases() {
+    let cases = TrackerCategory.allCases
+    XCTAssertEqual(cases.count, 4)
+    XCTAssertTrue(cases.contains(.sobriety))
+    XCTAssertTrue(cases.contains(.freedom))
+    XCTAssertTrue(cases.contains(.salvation))
+    XCTAssertTrue(cases.contains(.custom))
+  }
+
+  func testTrackerCategoryRawValues() {
+    XCTAssertEqual(TrackerCategory.sobriety.rawValue, "sobriety")
+    XCTAssertEqual(TrackerCategory.freedom.rawValue, "freedom")
+    XCTAssertEqual(TrackerCategory.salvation.rawValue, "salvation")
+    XCTAssertEqual(TrackerCategory.custom.rawValue, "custom")
+  }
+}


### PR DESCRIPTION
## Summary
- Add `TrackerCategory` enum with `sobriety`, `freedom`, `salvation`, `custom` cases
- Add `Tracker` SwiftData `@Model` with validation (non-empty title, no future start dates)
- Wire SwiftData model container into `RenewedApp`
- Add unit tests for model creation, default values, and category cases

## Test plan
- [x] `task build` compiles successfully
- [x] `task test` passes all new unit tests
- [x] Pre-commit hooks pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)