### PR TITLE
feat: #8: Add Tracker repository with SwiftData implementation

### DIFF
--- a/Sources/Repositories/SwiftDataTrackerRepository.swift
+++ b/Sources/Repositories/SwiftDataTrackerRepository.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftData
+
+enum TrackerRepositoryError: LocalizedError, Equatable {
+  case notFound(UUID)
+  case saveFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .notFound(let id):
+      return "Tracker with id \(id) not found"
+    case .saveFailed(let reason):
+      return "Failed to save: \(reason)"
+    }
+  }
+}
+
+final class SwiftDataTrackerRepository: TrackerRepository {
+  private let modelContext: ModelContext
+
+  init(modelContext: ModelContext) {
+    self.modelContext = modelContext
+  }
+
+  func fetchAll() async throws -> [Tracker] {
+    let descriptor = FetchDescriptor<Tracker>(
+      sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor)
+  }
+
+  func create(_ tracker: Tracker) async throws {
+    modelContext.insert(tracker)
+    do {
+      try modelContext.save()
+    } catch {
+      throw TrackerRepositoryError.saveFailed(error.localizedDescription)
+    }
+  }
+
+  func update(_ tracker: Tracker) async throws {
+    tracker.updatedAt = Date()
+    do {
+      try modelContext.save()
+    } catch {
+      throw TrackerRepositoryError.saveFailed(error.localizedDescription)
+    }
+  }
+
+  func delete(_ tracker: Tracker) async throws {
+    modelContext.delete(tracker)
+    do {
+      try modelContext.save()
+    } catch {
+      throw TrackerRepositoryError.saveFailed(error.localizedDescription)
+    }
+  }
+
+  func fetch(byId id: UUID) async throws -> Tracker? {
+    let descriptor = FetchDescriptor<Tracker>(
+      predicate: #Predicate { $0.id == id }
+    )
+    return try modelContext.fetch(descriptor).first
+  }
+}

--- a/Sources/Repositories/TrackerRepository.swift
+++ b/Sources/Repositories/TrackerRepository.swift
@@ -1,0 +1,7 @@
+protocol TrackerRepository {
+  func fetchAll() async throws -> [Tracker]
+  func create(_ tracker: Tracker) async throws
+  func update(_ tracker: Tracker) async throws
+  func delete(_ tracker: Tracker) async throws
+  func fetch(byId: UUID) async throws -> Tracker?
+}

--- a/Tests/Unit/TrackerRepositoryTests.swift
+++ b/Tests/Unit/TrackerRepositoryTests.swift
@@ -1,0 +1,154 @@
+import SwiftData
+import XCTest
+
+@testable import Renewed
+
+final class TrackerRepositoryTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var repository: SwiftDataTrackerRepository!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    container = try ModelContainer(for: Tracker.self, configurations: config)
+    context = ModelContext(container)
+    repository = SwiftDataTrackerRepository(modelContext: context)
+  }
+
+  override func tearDown() async throws {
+    repository = nil
+    context = nil
+    container = nil
+    try await super.tearDown()
+  }
+
+  // MARK: - Create
+
+  func testCreateInsertsTracker() async throws {
+    let tracker = try Tracker(
+      title: "Test Tracker",
+      startDate: Date(),
+      category: .sobriety,
+      iconName: "heart.fill",
+      color: "blue"
+    )
+
+    try await repository.create(tracker)
+
+    let results = try await repository.fetchAll()
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.title, "Test Tracker")
+  }
+
+  // MARK: - FetchAll
+
+  func testFetchAllReturnsEmpty() async throws {
+    let results = try await repository.fetchAll()
+    XCTAssertTrue(results.isEmpty)
+  }
+
+  func testFetchAllReturnsMultipleTrackers() async throws {
+    let tracker1 = try Tracker(
+      title: "First",
+      startDate: Date(),
+      category: .sobriety,
+      iconName: "heart.fill",
+      color: "blue"
+    )
+    let tracker2 = try Tracker(
+      title: "Second",
+      startDate: Date(),
+      category: .freedom,
+      iconName: "star",
+      color: "green"
+    )
+
+    try await repository.create(tracker1)
+    try await repository.create(tracker2)
+
+    let results = try await repository.fetchAll()
+    XCTAssertEqual(results.count, 2)
+  }
+
+  // MARK: - Fetch by ID
+
+  func testFetchByIdReturnsTracker() async throws {
+    let id = UUID()
+    let tracker = try Tracker(
+      id: id,
+      title: "Find Me",
+      startDate: Date(),
+      category: .salvation,
+      iconName: "cross",
+      color: "purple"
+    )
+
+    try await repository.create(tracker)
+
+    let found = try await repository.fetch(byId: id)
+    XCTAssertNotNil(found)
+    XCTAssertEqual(found?.title, "Find Me")
+  }
+
+  func testFetchByIdReturnsNilForNonExistent() async throws {
+    let result = try await repository.fetch(byId: UUID())
+    XCTAssertNil(result)
+  }
+
+  // MARK: - Update
+
+  func testUpdateSetsUpdatedAt() async throws {
+    let tracker = try Tracker(
+      title: "Original",
+      startDate: Date(),
+      category: .custom,
+      iconName: "flame",
+      color: "orange"
+    )
+    let originalUpdatedAt = tracker.updatedAt
+
+    try await repository.create(tracker)
+
+    // Small delay so updatedAt differs
+    try await Task.sleep(nanoseconds: 10_000_000)
+
+    tracker.title = "Modified"
+    try await repository.update(tracker)
+
+    XCTAssertEqual(tracker.title, "Modified")
+    XCTAssertGreaterThan(tracker.updatedAt, originalUpdatedAt)
+  }
+
+  // MARK: - Delete
+
+  func testDeleteRemovesTracker() async throws {
+    let tracker = try Tracker(
+      title: "Delete Me",
+      startDate: Date(),
+      category: .sobriety,
+      iconName: "heart.fill",
+      color: "red"
+    )
+
+    try await repository.create(tracker)
+    XCTAssertEqual(try await repository.fetchAll().count, 1)
+
+    try await repository.delete(tracker)
+    XCTAssertEqual(try await repository.fetchAll().count, 0)
+  }
+
+  // MARK: - Error descriptions
+
+  func testTrackerRepositoryErrorDescriptions() {
+    let id = UUID()
+    XCTAssertEqual(
+      TrackerRepositoryError.notFound(id).errorDescription,
+      "Tracker with id \(id) not found"
+    )
+    XCTAssertEqual(
+      TrackerRepositoryError.saveFailed("disk full").errorDescription,
+      "Failed to save: disk full"
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `TrackerRepository` protocol defining CRUD operations per ARCHITECTURE.md
- Add `SwiftDataTrackerRepository` implementation with `ModelContext`, error handling, and automatic `updatedAt` stamping
- Add comprehensive unit tests using in-memory `ModelContainer` for all CRUD operations and error cases

## Test plan
- [x] `task build` compiles successfully
- [x] `task test` passes all new + existing tests
- [x] Pre-commit hooks pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)