### PR TITLE
feat: #9: Add date calculation service with milestone support

### DIFF
--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -8,13 +8,19 @@
 
 /* Begin PBXBuildFile section */
 		1AF5FF2CEF690D00642C3A37 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E5DD9CF3AA88B8E5AB2620 /* ContentView.swift */; };
+		1D44749C7C93E4DC42A957ED /* TrackerRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */; };
 		3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */; };
+		396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */; };
+		4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */; };
 		5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */; };
 		61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411283F45317AA62F5D3BE1B /* TrackerTests.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
 		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
 		A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
+		B15C7257E8E078064EAEC121 /* TrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2A3306704DA73C96729906 /* TrackerRepository.swift */; };
+		BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */; };
 		C0F5E123488761034E91473B /* RenewedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */; };
+		DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */; };
 		FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */; };
 /* End PBXBuildFile section */
 
@@ -30,10 +36,13 @@
 
 /* Begin PBXFileReference section */
 		06DBE82BC759C230F1737AAA /* RenewedTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RenewedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCalculationServiceTests.swift; sourceTree = "<group>"; };
 		1F93ADC8867894D16B0BB5CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerListView.swift; sourceTree = "<group>"; };
+		2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCalculationService.swift; sourceTree = "<group>"; };
 		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
+		45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepositoryTests.swift; sourceTree = "<group>"; };
 		5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RenewedWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidget.swift; sourceTree = "<group>"; };
 		89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCategory.swift; sourceTree = "<group>"; };
@@ -43,6 +52,9 @@
 		A4DC09C6AA7D0BC666AEF25C /* Renewed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Renewed.entitlements; sourceTree = "<group>"; };
 		AA7C0BD36DBDA2FAFD62D4C0 /* Renewed.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Renewed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedTests.swift; sourceTree = "<group>"; };
+		DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTrackerRepository.swift; sourceTree = "<group>"; };
+		E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDateCalculationService.swift; sourceTree = "<group>"; };
+		FE2A3306704DA73C96729906 /* TrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -54,10 +66,21 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		300D5D2725D1182B06362B8F /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */,
+				FE2A3306704DA73C96729906 /* TrackerRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 		3745F514A792E246FEE3D813 /* Unit */ = {
 			isa = PBXGroup;
 			children = (
+				1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */,
 				C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */,
+				45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */,
 				411283F45317AA62F5D3BE1B /* TrackerTests.swift */,
 			);
 			path = Unit;
@@ -69,6 +92,8 @@
 				8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */,
 				DD01D6B839D6E24079587289 /* Config */,
 				4EB4CAB4DE016C09A69F313A /* Models */,
+				300D5D2725D1182B06362B8F /* Repositories */,
+				8937577D9A264EFF8BECA8F5 /* Services */,
 				077C726CDA976CAC133C651E /* Views */,
 			);
 			path = Sources;
@@ -100,6 +125,15 @@
 				442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		8937577D9A264EFF8BECA8F5 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */,
+				E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		8AE0149352ECA57921D2AF74 /* Products */ = {
@@ -248,10 +282,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				1AF5FF2CEF690D00642C3A37 /* ContentView.swift in Sources */,
+				396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */,
+				DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */,
 				FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */,
+				BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */,
 				9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */,
 				A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */,
 				5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */,
+				B15C7257E8E078064EAEC121 /* TrackerRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -259,7 +297,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */,
 				C0F5E123488761034E91473B /* RenewedTests.swift in Sources */,
+				1D44749C7C93E4DC42A957ED /* TrackerRepositoryTests.swift in Sources */,
 				61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Repositories/TrackerRepository.swift
+++ b/Sources/Repositories/TrackerRepository.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol TrackerRepository {
   func fetchAll() async throws -> [Tracker]
   func create(_ tracker: Tracker) async throws

--- a/Sources/Services/DateCalculationService.swift
+++ b/Sources/Services/DateCalculationService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct Milestone: Equatable {
+  let days: Int
+  let label: String
+}
+
+protocol DateCalculationService {
+  func daysSince(_ date: Date) -> Int
+  func daysBetween(_ start: Date, _ end: Date) -> Int
+  func nextMilestone(from startDate: Date) -> Milestone?
+  func milestoneReached(from startDate: Date) -> Milestone?
+}

--- a/Sources/Services/DefaultDateCalculationService.swift
+++ b/Sources/Services/DefaultDateCalculationService.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+final class DefaultDateCalculationService: DateCalculationService {
+  private let calendar: Calendar
+  private let now: () -> Date
+
+  init(calendar: Calendar = .current, now: @escaping () -> Date = { Date() }) {
+    self.calendar = calendar
+    self.now = now
+  }
+
+  func daysSince(_ date: Date) -> Int {
+    daysBetween(date, now())
+  }
+
+  func daysBetween(_ start: Date, _ end: Date) -> Int {
+    let startDay = calendar.startOfDay(for: start)
+    let endDay = calendar.startOfDay(for: end)
+    let components = calendar.dateComponents([.day], from: startDay, to: endDay)
+    return components.day ?? 0
+  }
+
+  func nextMilestone(from startDate: Date) -> Milestone? {
+    let elapsed = daysSince(startDate)
+    return milestones(upTo: elapsed + 365 * 10).first { $0.days > elapsed }
+  }
+
+  func milestoneReached(from startDate: Date) -> Milestone? {
+    let elapsed = daysSince(startDate)
+    return milestones(upTo: elapsed).last { $0.days == elapsed }
+  }
+
+  // MARK: - Private
+
+  private func milestones(upTo maxDays: Int) -> [Milestone] {
+    var result: [Milestone] = []
+
+    // Monthly milestones: 30, 60, 90 days
+    result.append(Milestone(days: 30, label: "1 Month"))
+    result.append(Milestone(days: 60, label: "2 Months"))
+    result.append(Milestone(days: 90, label: "3 Months"))
+
+    // 4-11 months (approximate days)
+    for month in 4...11 {
+      let days = month * 30
+      result.append(Milestone(days: days, label: "\(month) Months"))
+    }
+
+    // Yearly milestones: 1-5 years
+    for year in 1...5 {
+      let days = year * 365
+      let label = year == 1 ? "1 Year" : "\(year) Years"
+      result.append(Milestone(days: days, label: label))
+    }
+
+    // Every 5 years beyond 5
+    var year = 10
+    while year * 365 <= maxDays + 365 * 5 {
+      result.append(Milestone(days: year * 365, label: "\(year) Years"))
+      year += 5
+    }
+
+    return result.sorted { $0.days < $1.days }
+  }
+}

--- a/Tests/Unit/DateCalculationServiceTests.swift
+++ b/Tests/Unit/DateCalculationServiceTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+
+@testable import Renewed
+
+final class DateCalculationServiceTests: XCTestCase {
+  private var calendar: Calendar!
+  private var service: DefaultDateCalculationService!
+
+  override func setUp() {
+    super.setUp()
+    calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "America/New_York")!
+  }
+
+  override func tearDown() {
+    service = nil
+    calendar = nil
+    super.tearDown()
+  }
+
+  // MARK: - Helpers
+
+  private func makeService(now: Date) -> DefaultDateCalculationService {
+    DefaultDateCalculationService(calendar: calendar, now: { now })
+  }
+
+  private func date(year: Int, month: Int, day: Int, hour: Int = 0) -> Date {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    return calendar.date(from: components)!
+  }
+
+  // MARK: - daysSince
+
+  func testDaysSinceKnownDate() {
+    let now = date(year: 2025, month: 1, day: 11)
+    let service = makeService(now: now)
+
+    let start = date(year: 2025, month: 1, day: 1)
+    XCTAssertEqual(service.daysSince(start), 10)
+  }
+
+  func testDaysSinceSameDay() {
+    let now = date(year: 2025, month: 6, day: 15)
+    let service = makeService(now: now)
+
+    XCTAssertEqual(service.daysSince(now), 0)
+  }
+
+  // MARK: - daysBetween
+
+  func testDaysBetweenStartAndEnd() {
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let start = date(year: 2025, month: 3, day: 1)
+    let end = date(year: 2025, month: 3, day: 15)
+    XCTAssertEqual(service.daysBetween(start, end), 14)
+  }
+
+  func testDaysBetweenReversed() {
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let start = date(year: 2025, month: 3, day: 15)
+    let end = date(year: 2025, month: 3, day: 1)
+    XCTAssertEqual(service.daysBetween(start, end), -14)
+  }
+
+  func testDaysBetweenSameDay() {
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let d = date(year: 2025, month: 5, day: 10)
+    XCTAssertEqual(service.daysBetween(d, d), 0)
+  }
+
+  // MARK: - Leap year handling
+
+  func testDaysBetweenAcrossLeapYear() {
+    let service = makeService(now: date(year: 2024, month: 1, day: 1))
+
+    let start = date(year: 2024, month: 2, day: 28)
+    let end = date(year: 2024, month: 3, day: 1)
+    // 2024 is a leap year: Feb 28 -> Feb 29 -> Mar 1 = 2 days
+    XCTAssertEqual(service.daysBetween(start, end), 2)
+  }
+
+  func testDaysBetweenAcrossNonLeapYear() {
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let start = date(year: 2025, month: 2, day: 28)
+    let end = date(year: 2025, month: 3, day: 1)
+    // 2025 is not a leap year: Feb 28 -> Mar 1 = 1 day
+    XCTAssertEqual(service.daysBetween(start, end), 1)
+  }
+
+  // MARK: - DST transitions
+
+  func testDaysBetweenAcrossDSTSpringForward() {
+    // Spring forward 2025: March 9 in America/New_York
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let start = date(year: 2025, month: 3, day: 8)
+    let end = date(year: 2025, month: 3, day: 10)
+    XCTAssertEqual(service.daysBetween(start, end), 2)
+  }
+
+  func testDaysBetweenAcrossDSTFallBack() {
+    // Fall back 2025: November 2 in America/New_York
+    let service = makeService(now: date(year: 2025, month: 1, day: 1))
+
+    let start = date(year: 2025, month: 11, day: 1)
+    let end = date(year: 2025, month: 11, day: 3)
+    XCTAssertEqual(service.daysBetween(start, end), 2)
+  }
+
+  // MARK: - Monthly milestones
+
+  func testNextMilestoneAt29Days() {
+    let start = date(year: 2025, month: 1, day: 1)
+    let now = date(year: 2025, month: 1, day: 30)  // 29 days elapsed
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertEqual(milestone?.days, 30)
+    XCTAssertEqual(milestone?.label, "1 Month")
+  }
+
+  func testNextMilestoneAt30Days() {
+    let start = date(year: 2025, month: 1, day: 1)
+    let now = date(year: 2025, month: 1, day: 31)  // 30 days elapsed
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertEqual(milestone?.days, 60)
+    XCTAssertEqual(milestone?.label, "2 Months")
+  }
+
+  func testNextMilestoneAt90Days() {
+    let start = date(year: 2025, month: 1, day: 1)
+    let now = date(year: 2025, month: 4, day: 1)  // 90 days elapsed
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertEqual(milestone?.days, 120)
+    XCTAssertEqual(milestone?.label, "4 Months")
+  }
+
+  // MARK: - Yearly milestones
+
+  func testNextMilestoneAtOneYear() {
+    let start = date(year: 2024, month: 1, day: 1)
+    let now = date(year: 2024, month: 12, day: 31)  // 365 days (leap year)
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertNotNil(milestone)
+    XCTAssertTrue(milestone!.days > 365)
+  }
+
+  func testNextMilestoneBeyondFiveYears() {
+    let start = date(year: 2020, month: 1, day: 1)
+    let now = date(year: 2025, month: 1, day: 2)  // just over 5 years
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertNotNil(milestone)
+    // Should be the 10-year milestone (3650 days)
+    XCTAssertEqual(milestone?.days, 3650)
+    XCTAssertEqual(milestone?.label, "10 Years")
+  }
+
+  func testNextMilestoneBeyondTenYears() {
+    let start = date(year: 2010, month: 1, day: 1)
+    let now = date(year: 2020, month: 1, day: 2)  // just over 10 years
+    let service = makeService(now: now)
+
+    let milestone = service.nextMilestone(from: start)
+    XCTAssertNotNil(milestone)
+    XCTAssertEqual(milestone?.days, 5475)
+    XCTAssertEqual(milestone?.label, "15 Years")
+  }
+
+  // MARK: - milestoneReached
+
+  func testMilestoneReachedOnExactDay() {
+    let start = date(year: 2025, month: 1, day: 1)
+    let now = date(year: 2025, month: 1, day: 31)  // exactly 30 days
+    let service = makeService(now: now)
+
+    let milestone = service.milestoneReached(from: start)
+    XCTAssertEqual(milestone?.days, 30)
+    XCTAssertEqual(milestone?.label, "1 Month")
+  }
+
+  func testMilestoneReachedReturnsNilOnNonMilestoneDay() {
+    let start = date(year: 2025, month: 1, day: 1)
+    let now = date(year: 2025, month: 1, day: 20)  // 19 days, not a milestone
+    let service = makeService(now: now)
+
+    let milestone = service.milestoneReached(from: start)
+    XCTAssertNil(milestone)
+  }
+
+  func testMilestoneReachedAtOneYear() {
+    let start = date(year: 2025, month: 1, day: 1)
+    // 365 days later
+    let now = calendar.date(byAdding: .day, value: 365, to: start)!
+    let service = makeService(now: now)
+
+    let milestone = service.milestoneReached(from: start)
+    XCTAssertEqual(milestone?.days, 365)
+    XCTAssertEqual(milestone?.label, "1 Year")
+  }
+
+  func testMilestoneReachedAtDayZero() {
+    let start = date(year: 2025, month: 6, day: 1)
+    let service = makeService(now: start)
+
+    let milestone = service.milestoneReached(from: start)
+    XCTAssertNil(milestone)
+  }
+}

--- a/Tests/Unit/TrackerRepositoryTests.swift
+++ b/Tests/Unit/TrackerRepositoryTests.swift
@@ -10,7 +10,7 @@ final class TrackerRepositoryTests: XCTestCase {
 
   override func setUp() async throws {
     try await super.setUp()
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let config = ModelConfiguration(isStoredInMemoryOnly: true, cloudKitDatabase: .none)
     container = try ModelContainer(for: Tracker.self, configurations: config)
     context = ModelContext(container)
     repository = SwiftDataTrackerRepository(modelContext: context)
@@ -132,10 +132,12 @@ final class TrackerRepositoryTests: XCTestCase {
     )
 
     try await repository.create(tracker)
-    XCTAssertEqual(try await repository.fetchAll().count, 1)
+    let beforeDelete = try await repository.fetchAll()
+    XCTAssertEqual(beforeDelete.count, 1)
 
     try await repository.delete(tracker)
-    XCTAssertEqual(try await repository.fetchAll().count, 0)
+    let afterDelete = try await repository.fetchAll()
+    XCTAssertEqual(afterDelete.count, 0)
   }
 
   // MARK: - Error descriptions


### PR DESCRIPTION
## Summary
- Add `DateCalculationService` protocol and `DefaultDateCalculationService` implementation for calculating days since/between dates
- Include dynamic milestone generation (monthly, yearly, every-5-years) for tracker celebrations
- Add 19 comprehensive tests covering leap years, DST transitions, and edge cases
- Fix missing `import Foundation` in `TrackerRepository.swift` and async-in-autoclosure error in `TrackerRepositoryTests.swift`
- Fix CloudKit test failures by disabling CloudKit validation in unit test `ModelConfiguration`

## Test plan
- [x] All 19 DateCalculationServiceTests pass
- [x] All 8 TrackerRepositoryTests pass
- [x] All 32 tests pass locally
- [x] CI build succeeds

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)