### PR TITLE
feat: #11: Add tracker list view with cards and empty state

### DIFF
--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */; };
 		5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */; };
 		61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411283F45317AA62F5D3BE1B /* TrackerTests.swift */; };
+		7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
 		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
 		A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
@@ -22,6 +23,7 @@
 		BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */; };
 		C0F5E123488761034E91473B /* RenewedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */; };
 		DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */; };
+		E69521A7DE98EB5C684E7736 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */; };
 		F151E2A82E0346395A109774 /* AddTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */; };
 		FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */; };
 /* End PBXBuildFile section */
@@ -44,6 +46,7 @@
 		1F93ADC8867894D16B0BB5CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerListView.swift; sourceTree = "<group>"; };
 		2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackerView.swift; sourceTree = "<group>"; };
+		296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCalculationService.swift; sourceTree = "<group>"; };
 		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
@@ -56,6 +59,7 @@
 		A4DC09C6AA7D0BC666AEF25C /* Renewed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Renewed.entitlements; sourceTree = "<group>"; };
 		AA7C0BD36DBDA2FAFD62D4C0 /* Renewed.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Renewed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedTests.swift; sourceTree = "<group>"; };
+		D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCardView.swift; sourceTree = "<group>"; };
 		DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTrackerRepository.swift; sourceTree = "<group>"; };
 		E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDateCalculationService.swift; sourceTree = "<group>"; };
 		FE2A3306704DA73C96729906 /* TrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepository.swift; sourceTree = "<group>"; };
@@ -65,6 +69,7 @@
 		077C726CDA976CAC133C651E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				93460AFB8EFF8E2BCDFFBF1A /* Components */,
 				BEC697DDC7E3E6A6C5C577AA /* Screens */,
 			);
 			path = Views;
@@ -148,6 +153,15 @@
 				5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		93460AFB8EFF8E2BCDFFBF1A /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */,
+				D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		BEC697DDC7E3E6A6C5C577AA /* Screens */ = {
@@ -290,11 +304,13 @@
 				F151E2A82E0346395A109774 /* AddTrackerView.swift in Sources */,
 				396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */,
 				DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */,
+				E69521A7DE98EB5C684E7736 /* EmptyStateView.swift in Sources */,
 				459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */,
 				FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */,
 				3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */,
 				BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */,
 				9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */,
+				7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */,
 				A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */,
 				5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */,
 				B15C7257E8E078064EAEC121 /* TrackerRepository.swift in Sources */,

--- a/Sources/Views/Components/EmptyStateView.swift
+++ b/Sources/Views/Components/EmptyStateView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+  var iconName: String = "leaf.fill"
+  var message: String = "Your journey begins with the first step"
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Image(systemName: iconName)
+        .font(.system(size: 64))
+        .foregroundColor(.green)
+
+      Text(message)
+        .font(.title3)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .accessibilityElement(children: .combine)
+  }
+}

--- a/Sources/Views/Components/TrackerCardView.swift
+++ b/Sources/Views/Components/TrackerCardView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct TrackerCardView: View {
+  let tracker: Tracker
+  private let dateService: DateCalculationService = DefaultDateCalculationService()
+
+  private var dayCount: Int {
+    dateService.daysSince(tracker.startDate)
+  }
+
+  private var nextMilestone: Milestone? {
+    dateService.nextMilestone(from: tracker.startDate)
+  }
+
+  private var milestoneProgress: Double {
+    guard let milestone = nextMilestone else { return 1.0 }
+    guard milestone.days > 0 else { return 1.0 }
+    return min(Double(dayCount) / Double(milestone.days), 1.0)
+  }
+
+  private var trackerColor: Color {
+    switch tracker.color {
+    case "red": return .red
+    case "orange": return .orange
+    case "yellow": return .yellow
+    case "green": return .green
+    case "blue": return .blue
+    case "purple": return .purple
+    case "pink": return .pink
+    case "mint": return .mint
+    case "teal": return .teal
+    case "indigo": return .indigo
+    default: return .accentColor
+    }
+  }
+
+  private var categoryText: String {
+    switch tracker.category {
+    case .sobriety: return "sobriety"
+    case .freedom: return "freedom"
+    case .salvation: return "salvation"
+    case .custom: return "progress"
+    }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Image(systemName: tracker.iconName)
+          .font(.title2)
+          .foregroundColor(trackerColor)
+
+        Text(tracker.title)
+          .font(.headline)
+
+        Spacer()
+      }
+
+      HStack(alignment: .firstTextBaseline) {
+        Text("\(dayCount)")
+          .font(.system(size: 48, weight: .bold, design: .rounded))
+          .foregroundColor(trackerColor)
+
+        Text(dayCount == 1 ? "day" : "days")
+          .font(.title3)
+          .foregroundColor(.secondary)
+      }
+
+      Text("Celebrating \(dayCount) \(dayCount == 1 ? "day" : "days") of \(categoryText)")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      if let milestone = nextMilestone {
+        VStack(alignment: .leading, spacing: 4) {
+          ProgressView(value: milestoneProgress)
+            .tint(trackerColor)
+
+          Text("Next: \(milestone.label)")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+    }
+    .padding()
+    .background(Color(.systemBackground))
+    .cornerRadius(12)
+    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "\(tracker.title), \(dayCount) \(dayCount == 1 ? "day" : "days") of \(categoryText)"
+    )
+  }
+}

--- a/Sources/Views/Screens/TrackerListView.swift
+++ b/Sources/Views/Screens/TrackerListView.swift
@@ -1,19 +1,41 @@
+import SwiftData
 import SwiftUI
 
 struct TrackerListView: View {
+  @Query(sort: \Tracker.createdAt, order: .reverse) private var trackers: [Tracker]
+  @Environment(\.modelContext) private var modelContext
+
   var body: some View {
     NavigationStack {
-      VStack {
-        Image(systemName: "leaf.fill")
-          .font(.largeTitle)
-          .foregroundColor(.green)
-        Text("Renewed")
-          .font(.title)
-        Text("Your journey begins here")
-          .font(.subheadline)
-          .foregroundColor(.secondary)
+      Group {
+        if trackers.isEmpty {
+          EmptyStateView()
+        } else {
+          List {
+            ForEach(trackers) { tracker in
+              NavigationLink(value: tracker.id) {
+                TrackerCardView(tracker: tracker)
+              }
+              .listRowSeparator(.hidden)
+              .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+            }
+            .onDelete(perform: deleteTrackers)
+          }
+          .listStyle(.plain)
+        }
       }
       .navigationTitle("Trackers")
+      .navigationDestination(for: UUID.self) { _ in
+        Text("Tracker Detail")
+          .font(.title)
+          .foregroundColor(.secondary)
+      }
+    }
+  }
+
+  private func deleteTrackers(at offsets: IndexSet) {
+    for index in offsets {
+      modelContext.delete(trackers[index])
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace placeholder `TrackerListView` with `@Query`-driven reactive list of `TrackerCardView` components
- Add `TrackerCardView` showing icon, title, large day count, category text, and milestone progress bar
- Add reusable `EmptyStateView` for when no trackers exist
- Support swipe-to-delete via `@Environment(\.modelContext)`

## Test plan
- [x] `xcodegen generate` succeeds
- [x] Build compiles cleanly (`xcodebuild build`)
- [x] All 38 existing tests pass
- [x] Empty state displays when no trackers exist
- [x] Navigation title shows "Trackers"

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)