### PR TITLE
feat: #13: Add tracker card variants and dark mode polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select simulator
+        id: sim
+        run: |
+          SIM_NAME=$(xcrun simctl list devices available -j | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          print(next(dev['name'] for rt in d['devices'] for dev in d['devices'][rt] if dev['isAvailable'] and 'iPhone' in dev['name']))
+          ")
+          echo "name=$SIM_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Test
         run: >
           xcodebuild test
           -project Renewed.xcodeproj
           -scheme Renewed
           -sdk iphonesimulator
-          -destination "generic/platform=iOS Simulator"
+          -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
           -project Renewed.xcodeproj
           -scheme Renewed
           -sdk iphonesimulator
-          -destination "platform=iOS Simulator,name=iPhone 16"
+          -destination "generic/platform=iOS Simulator"

--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1D44749C7C93E4DC42A957ED /* TrackerRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */; };
+		24194D0CEC21650371DA3251 /* TrackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931C054D6732FD0D07615293 /* TrackerUITests.swift */; };
 		3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */; };
 		396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */; };
 		3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108CF87781BD007A756F5673 /* SettingsView.swift */; };
@@ -32,6 +33,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2872AC4A400C9C065C7EA2DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A94643718A78293D13D6D77B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FC36E598559AB6926C09BA4B;
+			remoteInfo = Renewed;
+		};
 		D4D713FF0761016F7BFFCAE2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A94643718A78293D13D6D77B /* Project object */;
@@ -60,10 +68,12 @@
 		6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidget.swift; sourceTree = "<group>"; };
 		89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCategory.swift; sourceTree = "<group>"; };
 		8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedApp.swift; sourceTree = "<group>"; };
+		931C054D6732FD0D07615293 /* TrackerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerUITests.swift; sourceTree = "<group>"; };
 		9CFE1C3C24BBDE97583AB65B /* Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracker.swift; sourceTree = "<group>"; };
 		A4DC09C6AA7D0BC666AEF25C /* Renewed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Renewed.entitlements; sourceTree = "<group>"; };
 		AA7C0BD36DBDA2FAFD62D4C0 /* Renewed.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Renewed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedTests.swift; sourceTree = "<group>"; };
+		D07AB3DF7ED6D197E86FB098 /* RenewedUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RenewedUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCardView.swift; sourceTree = "<group>"; };
 		DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTrackerRepository.swift; sourceTree = "<group>"; };
 		DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerGridView.swift; sourceTree = "<group>"; };
@@ -123,6 +133,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		6CEACE5089A17B944B188246 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				931C054D6732FD0D07615293 /* TrackerUITests.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		73F8723E515CD0BD6389788E = {
 			isa = PBXGroup;
 			children = (
@@ -156,6 +174,7 @@
 			children = (
 				AA7C0BD36DBDA2FAFD62D4C0 /* Renewed.app */,
 				06DBE82BC759C230F1737AAA /* RenewedTests.xctest */,
+				D07AB3DF7ED6D197E86FB098 /* RenewedUITests.xctest */,
 				5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */,
 			);
 			name = Products;
@@ -195,6 +214,7 @@
 		D2D1A9458D82041142BB1E8B /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6CEACE5089A17B944B188246 /* UI */,
 				3745F514A792E246FEE3D813 /* Unit */,
 			);
 			path = Tests;
@@ -229,6 +249,24 @@
 			productName = RenewedTests;
 			productReference = 06DBE82BC759C230F1737AAA /* RenewedTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D005558889A1BF47B8FF4F5D /* RenewedUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 27367D4ECAC493259CD8AE7C /* Build configuration list for PBXNativeTarget "RenewedUITests" */;
+			buildPhases = (
+				7F45C86E5F9B96732D21ABCF /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A280680B00FBC71B34207E2E /* PBXTargetDependency */,
+			);
+			name = RenewedUITests;
+			packageProductDependencies = (
+			);
+			productName = RenewedUITests;
+			productReference = D07AB3DF7ED6D197E86FB098 /* RenewedUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		D947BC9ECAEFF43486B8BB41 /* RenewedWidget */ = {
 			isa = PBXNativeTarget;
@@ -273,6 +311,9 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					D005558889A1BF47B8FF4F5D = {
+						TestTargetID = FC36E598559AB6926C09BA4B;
+					};
 				};
 			};
 			buildConfigurationList = 22F4DCCB1AA9C66D3EC33656 /* Build configuration list for PBXProject "Renewed" */;
@@ -291,6 +332,7 @@
 			targets = (
 				FC36E598559AB6926C09BA4B /* Renewed */,
 				0679313A064384C1C3136D8F /* RenewedTests */,
+				D005558889A1BF47B8FF4F5D /* RenewedUITests */,
 				D947BC9ECAEFF43486B8BB41 /* RenewedWidget */,
 			);
 		};
@@ -329,6 +371,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7F45C86E5F9B96732D21ABCF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24194D0CEC21650371DA3251 /* TrackerUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		89529C9F3F5D7A70E7F807C6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -347,6 +397,11 @@
 			isa = PBXTargetDependency;
 			target = FC36E598559AB6926C09BA4B /* Renewed */;
 			targetProxy = D4D713FF0761016F7BFFCAE2 /* PBXContainerItemProxy */;
+		};
+		A280680B00FBC71B34207E2E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FC36E598559AB6926C09BA4B /* Renewed */;
+			targetProxy = 2872AC4A400C9C065C7EA2DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -413,6 +468,23 @@
 			};
 			name = Debug;
 		};
+		5B87F88EDD5CB1FC0C53CC18 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.benniemosher.renewed.ui-tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Renewed;
+			};
+			name = Release;
+		};
 		6574447449FF73B7D78AB8F1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -477,6 +549,23 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Renewed.app/Renewed";
+			};
+			name = Debug;
+		};
+		CB54327E3A62950840D8DDFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.benniemosher.renewed.ui-tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Renewed;
 			};
 			name = Debug;
 		};
@@ -585,6 +674,15 @@
 			buildConfigurations = (
 				23022B3ECCEBA44C5F8571DB /* Debug */,
 				F1EC73B6107F5C7E6B1054FD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		27367D4ECAC493259CD8AE7C /* Build configuration list for PBXNativeTarget "RenewedUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB54327E3A62950840D8DDFF /* Debug */,
+				5B87F88EDD5CB1FC0C53CC18 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -14,7 +14,9 @@
 		459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF89D75ACB3DC857DBF506 /* MainTabView.swift */; };
 		4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */; };
 		5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */; };
+		5DEB4FFA44C7EAC3187CA2FA /* ColorPickerGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */; };
 		61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411283F45317AA62F5D3BE1B /* TrackerTests.swift */; };
+		623CF9E31AF35ECE4CD145D6 /* AddEditTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */; };
 		7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
 		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
@@ -24,6 +26,7 @@
 		C0F5E123488761034E91473B /* RenewedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */; };
 		DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */; };
 		E69521A7DE98EB5C684E7736 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */; };
+		EDB55016F595BDC395DFC3C0 /* IconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643321B76E30506023F5149A /* IconPickerView.swift */; };
 		F151E2A82E0346395A109774 /* AddTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */; };
 		FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */; };
 /* End PBXBuildFile section */
@@ -48,10 +51,12 @@
 		2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackerView.swift; sourceTree = "<group>"; };
 		296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCalculationService.swift; sourceTree = "<group>"; };
+		311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditTrackerView.swift; sourceTree = "<group>"; };
 		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
 		45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepositoryTests.swift; sourceTree = "<group>"; };
 		5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RenewedWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		643321B76E30506023F5149A /* IconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerView.swift; sourceTree = "<group>"; };
 		6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidget.swift; sourceTree = "<group>"; };
 		89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCategory.swift; sourceTree = "<group>"; };
 		8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedApp.swift; sourceTree = "<group>"; };
@@ -61,6 +66,7 @@
 		C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedTests.swift; sourceTree = "<group>"; };
 		D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCardView.swift; sourceTree = "<group>"; };
 		DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTrackerRepository.swift; sourceTree = "<group>"; };
+		DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerGridView.swift; sourceTree = "<group>"; };
 		E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDateCalculationService.swift; sourceTree = "<group>"; };
 		FE2A3306704DA73C96729906 /* TrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -158,7 +164,9 @@
 		93460AFB8EFF8E2BCDFFBF1A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */,
 				296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */,
+				643321B76E30506023F5149A /* IconPickerView.swift */,
 				D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */,
 			);
 			path = Components;
@@ -167,6 +175,7 @@
 		BEC697DDC7E3E6A6C5C577AA /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */,
 				2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */,
 				0FDF89D75ACB3DC857DBF506 /* MainTabView.swift */,
 				108CF87781BD007A756F5673 /* SettingsView.swift */,
@@ -301,10 +310,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				623CF9E31AF35ECE4CD145D6 /* AddEditTrackerView.swift in Sources */,
 				F151E2A82E0346395A109774 /* AddTrackerView.swift in Sources */,
+				5DEB4FFA44C7EAC3187CA2FA /* ColorPickerGridView.swift in Sources */,
 				396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */,
 				DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */,
 				E69521A7DE98EB5C684E7736 /* EmptyStateView.swift in Sources */,
+				EDB55016F595BDC395DFC3C0 /* IconPickerView.swift in Sources */,
 				459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */,
 				FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */,
 				3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */,

--- a/Renewed.xcodeproj/xcshareddata/xcschemes/Renewed.xcscheme
+++ b/Renewed.xcodeproj/xcshareddata/xcschemes/Renewed.xcscheme
@@ -64,6 +64,17 @@
                ReferencedContainer = "container:Renewed.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D005558889A1BF47B8FF4F5D"
+               BuildableName = "RenewedUITests.xctest"
+               BlueprintName = "RenewedUITests"
+               ReferencedContainer = "container:Renewed.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>

--- a/Sources/Models/Tracker.swift
+++ b/Sources/Models/Tracker.swift
@@ -17,14 +17,14 @@ enum TrackerValidationError: LocalizedError, Equatable {
 
 @Model
 final class Tracker {
-  var id: UUID
-  var title: String
-  var startDate: Date
-  var category: TrackerCategory
-  var iconName: String
-  var color: String
-  var createdAt: Date
-  var updatedAt: Date
+  var id: UUID = UUID()
+  var title: String = ""
+  var startDate: Date = Date()
+  var category: TrackerCategory = TrackerCategory.sobriety
+  var iconName: String = "leaf.fill"
+  var color: String = "green"
+  var createdAt: Date = Date()
+  var updatedAt: Date = Date()
 
   init(
     id: UUID = UUID(),

--- a/Sources/RenewedApp.swift
+++ b/Sources/RenewedApp.swift
@@ -3,10 +3,21 @@ import SwiftUI
 
 @main
 struct RenewedApp: App {
+  private let modelContainer: ModelContainer
+
+  init() {
+    if CommandLine.arguments.contains("--uitesting") {
+      let config = ModelConfiguration(isStoredInMemoryOnly: true)
+      modelContainer = try! ModelContainer(for: Tracker.self, configurations: config)
+    } else {
+      modelContainer = try! ModelContainer(for: Tracker.self)
+    }
+  }
+
   var body: some Scene {
     WindowGroup {
       MainTabView()
     }
-    .modelContainer(for: Tracker.self)
+    .modelContainer(modelContainer)
   }
 }

--- a/Sources/RenewedApp.swift
+++ b/Sources/RenewedApp.swift
@@ -3,10 +3,17 @@ import SwiftUI
 
 @main
 struct RenewedApp: App {
+  let container: ModelContainer
+
+  init() {
+    let config = ModelConfiguration(cloudKitDatabase: .none)
+    container = try! ModelContainer(for: Tracker.self, configurations: config)
+  }
+
   var body: some Scene {
     WindowGroup {
       MainTabView()
     }
-    .modelContainer(for: Tracker.self)
+    .modelContainer(container)
   }
 }

--- a/Sources/RenewedApp.swift
+++ b/Sources/RenewedApp.swift
@@ -3,17 +3,10 @@ import SwiftUI
 
 @main
 struct RenewedApp: App {
-  let container: ModelContainer
-
-  init() {
-    let config = ModelConfiguration(cloudKitDatabase: .none)
-    container = try! ModelContainer(for: Tracker.self, configurations: config)
-  }
-
   var body: some Scene {
     WindowGroup {
       MainTabView()
     }
-    .modelContainer(container)
+    .modelContainer(for: Tracker.self)
   }
 }

--- a/Sources/Views/Components/ColorPickerGridView.swift
+++ b/Sources/Views/Components/ColorPickerGridView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ColorPickerGridView: View {
+  @Binding var selectedColor: String
+
+  private let colorOptions: [(name: String, color: Color)] = [
+    ("red", .red),
+    ("orange", .orange),
+    ("yellow", .yellow),
+    ("green", .green),
+    ("blue", .blue),
+    ("purple", .purple),
+    ("pink", .pink),
+    ("mint", .mint),
+    ("teal", .teal),
+    ("indigo", .indigo),
+  ]
+
+  private let columns = Array(repeating: GridItem(.flexible()), count: 5)
+
+  var body: some View {
+    LazyVGrid(columns: columns, spacing: 12) {
+      ForEach(colorOptions, id: \.name) { option in
+        Circle()
+          .fill(option.color)
+          .frame(width: 36, height: 36)
+          .overlay(
+            Group {
+              if selectedColor == option.name {
+                Image(systemName: "checkmark")
+                  .font(.caption.bold())
+                  .foregroundColor(.white)
+              }
+            }
+          )
+          .onTapGesture {
+            selectedColor = option.name
+          }
+          .accessibilityLabel(option.name)
+          .accessibilityAddTraits(selectedColor == option.name ? .isSelected : [])
+      }
+    }
+  }
+}

--- a/Sources/Views/Components/EmptyStateView.swift
+++ b/Sources/Views/Components/EmptyStateView.swift
@@ -18,5 +18,6 @@ struct EmptyStateView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .accessibilityElement(children: .combine)
+    .accessibilityIdentifier("emptyStateView")
   }
 }

--- a/Sources/Views/Components/IconPickerView.swift
+++ b/Sources/Views/Components/IconPickerView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct IconPickerView: View {
+  @Binding var selectedIcon: String
+  let color: Color
+
+  private let icons = [
+    "leaf.fill", "heart.fill", "star.fill", "flame.fill", "drop.fill",
+    "sun.max.fill", "moon.fill", "bolt.fill", "shield.fill", "hand.raised.fill",
+    "figure.walk", "brain.head.profile", "lungs.fill", "cross.fill", "sparkles",
+    "trophy.fill", "flag.fill", "mountain.2.fill", "sunrise.fill", "bird.fill",
+  ]
+
+  private let columns = Array(repeating: GridItem(.flexible()), count: 5)
+
+  var body: some View {
+    LazyVGrid(columns: columns, spacing: 12) {
+      ForEach(icons, id: \.self) { icon in
+        Image(systemName: icon)
+          .font(.title2)
+          .frame(width: 44, height: 44)
+          .foregroundColor(selectedIcon == icon ? .white : color)
+          .background(
+            RoundedRectangle(cornerRadius: 8)
+              .fill(selectedIcon == icon ? color : color.opacity(0.1))
+          )
+          .onTapGesture {
+            selectedIcon = icon
+          }
+          .accessibilityLabel(icon)
+          .accessibilityAddTraits(selectedIcon == icon ? .isSelected : [])
+      }
+    }
+  }
+}

--- a/Sources/Views/Components/TrackerCardView.swift
+++ b/Sources/Views/Components/TrackerCardView.swift
@@ -1,8 +1,22 @@
 import SwiftUI
 
+extension TrackerCardView {
+  enum CardStyle {
+    case compact
+    case large
+    case square
+  }
+}
+
 struct TrackerCardView: View {
+  @Environment(\.colorScheme) private var colorScheme
   let tracker: Tracker
+  var style: CardStyle = .compact
   private let dateService: DateCalculationService = DefaultDateCalculationService()
+
+  @ScaledMetric(relativeTo: .largeTitle) private var dayCountSize: CGFloat = 48
+  @ScaledMetric(relativeTo: .largeTitle) private var largeDayCountSize: CGFloat = 64
+  @ScaledMetric(relativeTo: .title) private var squareDayCountSize: CGFloat = 36
 
   private var dayCount: Int {
     dateService.daysSince(tracker.startDate)
@@ -43,7 +57,40 @@ struct TrackerCardView: View {
     }
   }
 
+  private var dayLabel: String {
+    dayCount == 1 ? "day" : "days"
+  }
+
+  private var formattedStartDate: String {
+    tracker.startDate.formatted(date: .long, time: .omitted)
+  }
+
   var body: some View {
+    Group {
+      switch style {
+      case .compact:
+        compactBody
+      case .large:
+        largeBody
+      case .square:
+        squareBody
+      }
+    }
+    .background(Color(.secondarySystemBackground))
+    .cornerRadius(12)
+    .shadow(
+      color: colorScheme == .dark ? .white.opacity(0.08) : .black.opacity(0.1),
+      radius: 4, x: 0, y: 2
+    )
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "\(tracker.title), \(dayCount) \(dayLabel) of \(categoryText)"
+    )
+  }
+
+  // MARK: - Compact
+
+  private var compactBody: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack {
         Image(systemName: tracker.iconName)
@@ -58,15 +105,15 @@ struct TrackerCardView: View {
 
       HStack(alignment: .firstTextBaseline) {
         Text("\(dayCount)")
-          .font(.system(size: 48, weight: .bold, design: .rounded))
+          .font(.system(size: dayCountSize, weight: .bold, design: .rounded))
           .foregroundColor(trackerColor)
 
-        Text(dayCount == 1 ? "day" : "days")
+        Text(dayLabel)
           .font(.title3)
           .foregroundColor(.secondary)
       }
 
-      Text("Celebrating \(dayCount) \(dayCount == 1 ? "day" : "days") of \(categoryText)")
+      Text("Celebrating \(dayCount) \(dayLabel) of \(categoryText)")
         .font(.subheadline)
         .foregroundColor(.secondary)
 
@@ -82,12 +129,135 @@ struct TrackerCardView: View {
       }
     }
     .padding()
-    .background(Color(.systemBackground))
-    .cornerRadius(12)
-    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(
-      "\(tracker.title), \(dayCount) \(dayCount == 1 ? "day" : "days") of \(categoryText)"
-    )
   }
+
+  // MARK: - Large
+
+  private var largeBody: some View {
+    VStack(spacing: 16) {
+      Image(systemName: tracker.iconName)
+        .font(.largeTitle)
+        .foregroundColor(trackerColor)
+
+      Text(tracker.title)
+        .font(.title2.bold())
+        .multilineTextAlignment(.center)
+
+      HStack(alignment: .firstTextBaseline, spacing: 4) {
+        Text("\(dayCount)")
+          .font(.system(size: largeDayCountSize, weight: .bold, design: .rounded))
+          .foregroundColor(trackerColor)
+
+        Text(dayLabel)
+          .font(.title2)
+          .foregroundColor(.secondary)
+      }
+
+      Text("Celebrating \(dayCount) \(dayLabel) of \(categoryText)")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+
+      Text("Since \(formattedStartDate)")
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      if let milestone = nextMilestone {
+        VStack(spacing: 6) {
+          ProgressView(value: milestoneProgress)
+            .tint(trackerColor)
+
+          Text("Next milestone: \(milestone.label)")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .padding(.horizontal)
+      }
+    }
+    .padding()
+    .frame(maxWidth: .infinity)
+  }
+
+  // MARK: - Square
+
+  private var squareBody: some View {
+    VStack(spacing: 8) {
+      Image(systemName: tracker.iconName)
+        .font(.title2)
+        .foregroundColor(trackerColor)
+
+      Text("\(dayCount)")
+        .font(.system(size: squareDayCountSize, weight: .bold, design: .rounded))
+        .foregroundColor(trackerColor)
+        .minimumScaleFactor(0.5)
+
+      Text(dayLabel)
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      Text(tracker.title)
+        .font(.caption2.bold())
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+// MARK: - Previews
+
+#Preview("Compact") {
+  let tracker = try! Tracker(
+    title: "Alcohol Free",
+    startDate: Calendar.current.date(byAdding: .day, value: -42, to: Date())!,
+    category: .sobriety,
+    iconName: "drop.fill",
+    color: "blue"
+  )
+  TrackerCardView(tracker: tracker, style: .compact)
+    .padding()
+}
+
+#Preview("Large") {
+  let tracker = try! Tracker(
+    title: "Alcohol Free",
+    startDate: Calendar.current.date(byAdding: .day, value: -42, to: Date())!,
+    category: .sobriety,
+    iconName: "drop.fill",
+    color: "blue"
+  )
+  TrackerCardView(tracker: tracker, style: .large)
+    .padding()
+}
+
+#Preview("Square") {
+  let tracker = try! Tracker(
+    title: "Alcohol Free",
+    startDate: Calendar.current.date(byAdding: .day, value: -42, to: Date())!,
+    category: .sobriety,
+    iconName: "drop.fill",
+    color: "blue"
+  )
+  TrackerCardView(tracker: tracker, style: .square)
+    .frame(width: 155, height: 155)
+    .padding()
+}
+
+#Preview("Dynamic Type - Large Accessibility") {
+  let tracker = try! Tracker(
+    title: "Smoke Free",
+    startDate: Calendar.current.date(byAdding: .day, value: -100, to: Date())!,
+    category: .freedom,
+    iconName: "wind",
+    color: "green"
+  )
+  VStack(spacing: 20) {
+    TrackerCardView(tracker: tracker, style: .compact)
+    TrackerCardView(tracker: tracker, style: .large)
+    TrackerCardView(tracker: tracker, style: .square)
+      .frame(width: 200, height: 200)
+  }
+  .padding()
+  .environment(\.dynamicTypeSize, .accessibility3)
 }

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -1,0 +1,150 @@
+import SwiftData
+import SwiftUI
+
+struct AddEditTrackerView: View {
+  @Environment(\.modelContext) private var modelContext
+  @Environment(\.dismiss) private var dismiss
+
+  private let tracker: Tracker?
+
+  @State private var title: String
+  @State private var startDate: Date
+  @State private var category: TrackerCategory
+  @State private var iconName: String
+  @State private var color: String
+  @State private var errorMessage: String?
+
+  private var isEditMode: Bool { tracker != nil }
+
+  private var selectedColor: Color {
+    switch color {
+    case "red": return .red
+    case "orange": return .orange
+    case "yellow": return .yellow
+    case "green": return .green
+    case "blue": return .blue
+    case "purple": return .purple
+    case "pink": return .pink
+    case "mint": return .mint
+    case "teal": return .teal
+    case "indigo": return .indigo
+    default: return .accentColor
+    }
+  }
+
+  init(tracker: Tracker? = nil) {
+    self.tracker = tracker
+    _title = State(initialValue: tracker?.title ?? "")
+    _startDate = State(initialValue: tracker?.startDate ?? Date())
+    _category = State(initialValue: tracker?.category ?? .sobriety)
+    _iconName = State(initialValue: tracker?.iconName ?? "leaf.fill")
+    _color = State(initialValue: tracker?.color ?? "green")
+    _errorMessage = State(initialValue: nil)
+  }
+
+  var body: some View {
+    Form {
+      Section("What are you celebrating?") {
+        TextField("e.g. Sobriety, New Beginning", text: $title)
+      }
+
+      Section("When did your journey begin?") {
+        DatePicker(
+          "Start Date",
+          selection: $startDate,
+          in: ...Date(),
+          displayedComponents: .date
+        )
+      }
+
+      Section("Category") {
+        Picker("Category", selection: $category) {
+          ForEach(TrackerCategory.allCases, id: \.self) { cat in
+            Text(cat.rawValue.capitalized).tag(cat)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Icon") {
+        IconPickerView(selectedIcon: $iconName, color: selectedColor)
+      }
+
+      Section("Color") {
+        ColorPickerGridView(selectedColor: $color)
+      }
+
+      if let errorMessage {
+        Section {
+          Text(errorMessage)
+            .foregroundColor(.red)
+            .font(.callout)
+        }
+      }
+    }
+    .navigationTitle(isEditMode ? "Edit Tracker" : "New Tracker")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .cancellationAction) {
+        Button("Cancel") {
+          dismiss()
+        }
+      }
+      ToolbarItem(placement: .confirmationAction) {
+        Button("Save") {
+          save()
+        }
+      }
+    }
+  }
+
+  private func save() {
+    errorMessage = nil
+
+    if isEditMode, let tracker {
+      // Validate before mutating
+      guard !title.isEmpty else {
+        errorMessage = TrackerValidationError.emptyTitle.errorDescription
+        return
+      }
+      guard startDate <= Date() else {
+        errorMessage = TrackerValidationError.futureDateNotAllowed.errorDescription
+        return
+      }
+
+      tracker.title = title
+      tracker.startDate = startDate
+      tracker.category = category
+      tracker.iconName = iconName
+      tracker.color = color
+      tracker.updatedAt = Date()
+    } else {
+      do {
+        let newTracker = try Tracker(
+          title: title,
+          startDate: startDate,
+          category: category,
+          iconName: iconName,
+          color: color
+        )
+        modelContext.insert(newTracker)
+      } catch let error as TrackerValidationError {
+        errorMessage = error.errorDescription
+        return
+      } catch {
+        errorMessage = error.localizedDescription
+        return
+      }
+    }
+
+    dismiss()
+  }
+}
+
+struct AddEditTrackerView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationStack {
+      AddEditTrackerView()
+    }
+  }
+}

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -101,14 +101,11 @@ struct AddEditTrackerView: View {
         }
       }
     }
-    .confirmationDialog(
-      "Delete Tracker",
-      isPresented: $showDeleteConfirmation,
-      titleVisibility: .visible
-    ) {
+    .alert("Delete Tracker", isPresented: $showDeleteConfirmation) {
       Button("Delete", role: .destructive) {
         deleteTracker()
       }
+      Button("Cancel", role: .cancel) {}
     } message: {
       Text("Are you sure? This cannot be undone.")
     }

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -8,7 +8,7 @@ struct AddEditTrackerView: View {
   private let tracker: Tracker?
   private let onSave: (() -> Void)?
 
-  @State private var title: String
+  @State private var customName: String
   @State private var startDate: Date
   @State private var category: TrackerCategory
   @State private var iconName: String
@@ -16,6 +16,13 @@ struct AddEditTrackerView: View {
   @State private var errorMessage: String?
 
   private var isEditMode: Bool { tracker != nil }
+
+  private var resolvedTitle: String {
+    if category == .custom {
+      return customName
+    }
+    return category.rawValue.capitalized
+  }
 
   private var selectedColor: Color {
     switch color {
@@ -36,7 +43,7 @@ struct AddEditTrackerView: View {
   init(tracker: Tracker? = nil, onSave: (() -> Void)? = nil) {
     self.tracker = tracker
     self.onSave = onSave
-    _title = State(initialValue: tracker?.title ?? "")
+    _customName = State(initialValue: tracker?.category == .custom ? (tracker?.title ?? "") : "")
     _startDate = State(initialValue: tracker?.startDate ?? Date())
     _category = State(initialValue: tracker?.category ?? .sobriety)
     _iconName = State(initialValue: tracker?.iconName ?? "leaf.fill")
@@ -47,7 +54,16 @@ struct AddEditTrackerView: View {
   var body: some View {
     Form {
       Section("What are you celebrating?") {
-        TextField("e.g. Sobriety, New Beginning", text: $title)
+        Picker("Category", selection: $category) {
+          ForEach(TrackerCategory.allCases, id: \.self) { cat in
+            Text(cat.rawValue.capitalized).tag(cat)
+          }
+        }
+        .pickerStyle(.segmented)
+
+        if category == .custom {
+          TextField("Give it a name", text: $customName)
+        }
       }
 
       Section("When did your journey begin?") {
@@ -57,15 +73,6 @@ struct AddEditTrackerView: View {
           in: ...Date(),
           displayedComponents: .date
         )
-      }
-
-      Section("Category") {
-        Picker("Category", selection: $category) {
-          ForEach(TrackerCategory.allCases, id: \.self) { cat in
-            Text(cat.rawValue.capitalized).tag(cat)
-          }
-        }
-        .pickerStyle(.segmented)
       }
 
       Section("Icon") {
@@ -105,9 +112,10 @@ struct AddEditTrackerView: View {
   private func save() {
     errorMessage = nil
 
+    let titleToSave = resolvedTitle
+
     if isEditMode, let tracker {
-      // Validate before mutating
-      guard !title.isEmpty else {
+      guard !titleToSave.isEmpty else {
         errorMessage = TrackerValidationError.emptyTitle.errorDescription
         return
       }
@@ -116,7 +124,7 @@ struct AddEditTrackerView: View {
         return
       }
 
-      tracker.title = title
+      tracker.title = titleToSave
       tracker.startDate = startDate
       tracker.category = category
       tracker.iconName = iconName
@@ -125,7 +133,7 @@ struct AddEditTrackerView: View {
     } else {
       do {
         let newTracker = try Tracker(
-          title: title,
+          title: titleToSave,
           startDate: startDate,
           category: category,
           iconName: iconName,
@@ -150,7 +158,7 @@ struct AddEditTrackerView: View {
   }
 
   private func resetForm() {
-    title = ""
+    customName = ""
     startDate = Date()
     category = .sobriety
     iconName = "leaf.fill"

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -61,9 +61,11 @@ struct AddEditTrackerView: View {
           }
         }
         .pickerStyle(.segmented)
+        .accessibilityIdentifier("categoryPicker")
 
         if category == .custom {
           TextField("Give it a name", text: $customName)
+            .accessibilityIdentifier("customNameField")
         }
       }
 
@@ -74,6 +76,7 @@ struct AddEditTrackerView: View {
           in: ...Date(),
           displayedComponents: .date
         )
+        .accessibilityIdentifier("startDatePicker")
       }
 
       Section("Icon") {
@@ -89,6 +92,7 @@ struct AddEditTrackerView: View {
           Text(errorMessage)
             .foregroundColor(.red)
             .font(.callout)
+            .accessibilityIdentifier("errorMessage")
         }
       }
 
@@ -97,6 +101,7 @@ struct AddEditTrackerView: View {
           Button("Delete Tracker", role: .destructive) {
             showDeleteConfirmation = true
           }
+          .accessibilityIdentifier("deleteButton")
           .frame(maxWidth: .infinity)
         }
       }

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -130,6 +130,13 @@ struct AddEditTrackerView: View {
       tracker.iconName = iconName
       tracker.color = color
       tracker.updatedAt = Date()
+
+      do {
+        try modelContext.save()
+      } catch {
+        errorMessage = error.localizedDescription
+        return
+      }
     } else {
       do {
         let newTracker = try Tracker(
@@ -140,6 +147,7 @@ struct AddEditTrackerView: View {
           color: color
         )
         modelContext.insert(newTracker)
+        try modelContext.save()
       } catch let error as TrackerValidationError {
         errorMessage = error.errorDescription
         return

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -6,6 +6,7 @@ struct AddEditTrackerView: View {
   @Environment(\.dismiss) private var dismiss
 
   private let tracker: Tracker?
+  private let onSave: (() -> Void)?
 
   @State private var title: String
   @State private var startDate: Date
@@ -32,8 +33,9 @@ struct AddEditTrackerView: View {
     }
   }
 
-  init(tracker: Tracker? = nil) {
+  init(tracker: Tracker? = nil, onSave: (() -> Void)? = nil) {
     self.tracker = tracker
+    self.onSave = onSave
     _title = State(initialValue: tracker?.title ?? "")
     _startDate = State(initialValue: tracker?.startDate ?? Date())
     _category = State(initialValue: tracker?.category ?? .sobriety)
@@ -85,9 +87,11 @@ struct AddEditTrackerView: View {
     .navigationTitle(isEditMode ? "Edit Tracker" : "New Tracker")
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
-      ToolbarItem(placement: .cancellationAction) {
-        Button("Cancel") {
-          dismiss()
+      if isEditMode {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") {
+            dismiss()
+          }
         }
       }
       ToolbarItem(placement: .confirmationAction) {
@@ -137,7 +141,21 @@ struct AddEditTrackerView: View {
       }
     }
 
-    dismiss()
+    if isEditMode {
+      dismiss()
+    } else {
+      resetForm()
+      onSave?()
+    }
+  }
+
+  private func resetForm() {
+    title = ""
+    startDate = Date()
+    category = .sobriety
+    iconName = "leaf.fill"
+    color = "green"
+    errorMessage = nil
   }
 }
 

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -14,6 +14,7 @@ struct AddEditTrackerView: View {
   @State private var iconName: String
   @State private var color: String
   @State private var errorMessage: String?
+  @State private var showDeleteConfirmation = false
 
   private var isEditMode: Bool { tracker != nil }
 
@@ -90,6 +91,26 @@ struct AddEditTrackerView: View {
             .font(.callout)
         }
       }
+
+      if isEditMode {
+        Section {
+          Button("Delete Tracker", role: .destructive) {
+            showDeleteConfirmation = true
+          }
+          .frame(maxWidth: .infinity)
+        }
+      }
+    }
+    .confirmationDialog(
+      "Delete Tracker",
+      isPresented: $showDeleteConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Delete", role: .destructive) {
+        deleteTracker()
+      }
+    } message: {
+      Text("Are you sure? This cannot be undone.")
     }
     .navigationTitle(isEditMode ? "Edit Tracker" : "New Tracker")
     .navigationBarTitleDisplayMode(.inline)
@@ -163,6 +184,13 @@ struct AddEditTrackerView: View {
       resetForm()
       onSave?()
     }
+  }
+
+  private func deleteTracker() {
+    guard let tracker else { return }
+    modelContext.delete(tracker)
+    try? modelContext.save()
+    dismiss()
   }
 
   private func resetForm() {

--- a/Sources/Views/Screens/AddTrackerView.swift
+++ b/Sources/Views/Screens/AddTrackerView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
 struct AddTrackerView: View {
+  var onSave: (() -> Void)?
+
   var body: some View {
     NavigationStack {
-      AddEditTrackerView()
+      AddEditTrackerView(onSave: onSave)
     }
   }
 }

--- a/Sources/Views/Screens/AddTrackerView.swift
+++ b/Sources/Views/Screens/AddTrackerView.swift
@@ -3,14 +3,7 @@ import SwiftUI
 struct AddTrackerView: View {
   var body: some View {
     NavigationStack {
-      VStack {
-        Image(systemName: "plus.circle.fill")
-          .font(.largeTitle)
-          .foregroundColor(.accentColor)
-        Text("Add Tracker")
-          .font(.title)
-      }
-      .navigationTitle("Add Tracker")
+      AddEditTrackerView()
     }
   }
 }

--- a/Sources/Views/Screens/MainTabView.swift
+++ b/Sources/Views/Screens/MainTabView.swift
@@ -1,22 +1,27 @@
 import SwiftUI
 
 struct MainTabView: View {
+  @State private var selectedTab = 0
+
   var body: some View {
-    TabView {
+    TabView(selection: $selectedTab) {
       TrackerListView()
         .tabItem {
           Label("Trackers", systemImage: "list.bullet")
         }
+        .tag(0)
 
-      AddTrackerView()
+      AddTrackerView(onSave: { selectedTab = 0 })
         .tabItem {
           Label("Add", systemImage: "plus.circle.fill")
         }
+        .tag(1)
 
       SettingsView()
         .tabItem {
           Label("Settings", systemImage: "gear")
         }
+        .tag(2)
     }
   }
 }

--- a/Sources/Views/Screens/TrackerListView.swift
+++ b/Sources/Views/Screens/TrackerListView.swift
@@ -22,6 +22,7 @@ struct TrackerListView: View {
             .onDelete(perform: deleteTrackers)
           }
           .listStyle(.plain)
+          .accessibilityIdentifier("trackerList")
         }
       }
       .navigationTitle("Trackers")

--- a/Sources/Views/Screens/TrackerListView.swift
+++ b/Sources/Views/Screens/TrackerListView.swift
@@ -25,10 +25,10 @@ struct TrackerListView: View {
         }
       }
       .navigationTitle("Trackers")
-      .navigationDestination(for: UUID.self) { _ in
-        Text("Tracker Detail")
-          .font(.title)
-          .foregroundColor(.secondary)
+      .navigationDestination(for: UUID.self) { trackerId in
+        if let tracker = trackers.first(where: { $0.id == trackerId }) {
+          AddEditTrackerView(tracker: tracker)
+        }
       }
     }
   }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,9 @@ tasks:
   test:
     desc: Run unit tests
     cmds:
-      - xcodebuild test -project Renewed.xcodeproj -scheme Renewed -sdk iphonesimulator -destination "platform=iOS Simulator"
+      - |
+        SIM_NAME=$(xcrun simctl list devices available -j | python3 -c "import sys,json; d=json.load(sys.stdin); print(next(dev['name'] for rt in d['devices'] for dev in d['devices'][rt] if dev['isAvailable'] and 'iPhone' in dev['name']))")
+        xcodebuild test -project Renewed.xcodeproj -scheme Renewed -sdk iphonesimulator -destination "platform=iOS Simulator,name=$SIM_NAME"
 
   lint:
     desc: Run pre-commit hooks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
   test:
     desc: Run unit tests
     cmds:
-      - xcodebuild test -project Renewed.xcodeproj -scheme Renewed -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 15"
+      - xcodebuild test -project Renewed.xcodeproj -scheme Renewed -sdk iphonesimulator -destination "platform=iOS Simulator"
 
   lint:
     desc: Run pre-commit hooks

--- a/Tests/UI/TrackerUITests.swift
+++ b/Tests/UI/TrackerUITests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+final class TrackerUITests: XCTestCase {
+  private var app: XCUIApplication!
+
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+    app = XCUIApplication()
+    app.launchArguments = ["--uitesting"]
+    app.launch()
+  }
+
+  override func tearDown() {
+    app = nil
+    super.tearDown()
+  }
+
+  // MARK: - Helpers
+
+  /// Creates a tracker with the default sobriety category and returns to the Trackers tab.
+  private func createDefaultTracker() {
+    app.tabBars.buttons["Add"].tap()
+    app.buttons["Save"].tap()
+  }
+
+  /// Creates a tracker with a custom name and returns to the Trackers tab.
+  private func createCustomTracker(name: String) {
+    app.tabBars.buttons["Add"].tap()
+
+    let categoryPicker = app.segmentedControls["categoryPicker"]
+    categoryPicker.buttons["Custom"].tap()
+
+    let nameField = app.textFields["customNameField"]
+    nameField.tap()
+    nameField.typeText(name)
+
+    app.buttons["Save"].tap()
+  }
+
+  /// Asserts the tracker list is showing the empty state.
+  private func assertEmptyState() {
+    let emptyStateText = app.staticTexts["Your journey begins with the first step"]
+    XCTAssertTrue(emptyStateText.waitForExistence(timeout: 5))
+  }
+
+  // MARK: - Create
+
+  func testCreateTracker() {
+    app.tabBars.buttons["Add"].tap()
+
+    XCTAssertTrue(app.navigationBars["New Tracker"].exists)
+
+    app.buttons["Save"].tap()
+
+    // After save, the app switches to the Trackers tab
+    let list = app.collectionViews["trackerList"]
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+
+    // The default category "Sobriety" should appear in the list
+    XCTAssertTrue(app.staticTexts["Sobriety"].waitForExistence(timeout: 3))
+  }
+
+  func testCreateCustomTracker() {
+    createCustomTracker(name: "No Sugar")
+
+    let list = app.collectionViews["trackerList"]
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+
+    XCTAssertTrue(app.staticTexts["No Sugar"].waitForExistence(timeout: 3))
+  }
+
+  // MARK: - Edit
+
+  func testEditTracker() {
+    createDefaultTracker()
+
+    // Wait for the list to appear and tap the tracker
+    let list = app.collectionViews["trackerList"]
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+
+    let sobrietyText = app.staticTexts["Sobriety"]
+    XCTAssertTrue(sobrietyText.waitForExistence(timeout: 3))
+    sobrietyText.tap()
+
+    // Verify we're in edit mode
+    XCTAssertTrue(app.navigationBars["Edit Tracker"].waitForExistence(timeout: 3))
+
+    // Change to Custom category and enter a name
+    let categoryPicker = app.segmentedControls["categoryPicker"]
+    categoryPicker.buttons["Custom"].tap()
+
+    let nameField = app.textFields["customNameField"]
+    nameField.tap()
+    nameField.typeText("No Caffeine")
+
+    app.buttons["Save"].tap()
+
+    // Verify the list shows the updated name
+    XCTAssertTrue(app.staticTexts["No Caffeine"].waitForExistence(timeout: 3))
+    XCTAssertFalse(app.staticTexts["Sobriety"].exists)
+  }
+
+  // MARK: - Delete
+
+  func testDeleteTrackerFromEditView() {
+    createDefaultTracker()
+
+    let list = app.collectionViews["trackerList"]
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+
+    let sobrietyText = app.staticTexts["Sobriety"]
+    XCTAssertTrue(sobrietyText.waitForExistence(timeout: 3))
+    sobrietyText.tap()
+
+    XCTAssertTrue(app.navigationBars["Edit Tracker"].waitForExistence(timeout: 3))
+
+    // Scroll down to find and tap delete button
+    let deleteButton = app.buttons["deleteButton"]
+    app.swipeUp()
+    XCTAssertTrue(deleteButton.waitForExistence(timeout: 3))
+    deleteButton.tap()
+
+    // Confirm deletion in alert
+    let deleteAlert = app.alerts["Delete Tracker"]
+    XCTAssertTrue(deleteAlert.waitForExistence(timeout: 3))
+    deleteAlert.buttons["Delete"].tap()
+
+    // Wait for navigation back to list and verify empty state
+    assertEmptyState()
+  }
+
+  func testSwipeToDelete() {
+    createDefaultTracker()
+
+    let list = app.collectionViews["trackerList"]
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+
+    // Swipe on the first cell in the list
+    let firstCell = list.cells.firstMatch
+    XCTAssertTrue(firstCell.waitForExistence(timeout: 3))
+    firstCell.swipeLeft()
+
+    let deleteButton = app.buttons["Delete"]
+    XCTAssertTrue(deleteButton.waitForExistence(timeout: 3))
+    deleteButton.tap()
+
+    // Verify list is now empty
+    assertEmptyState()
+  }
+
+  // MARK: - Validation
+
+  func testValidationEmptyCustomName() {
+    app.tabBars.buttons["Add"].tap()
+
+    // Select Custom category but leave name empty
+    // Use buttons query directly - segmented control buttons are accessible this way
+    let customSegment = app.buttons["Custom"]
+    XCTAssertTrue(customSegment.waitForExistence(timeout: 3))
+    customSegment.tap()
+
+    // Verify the custom name text field appeared (confirms category changed)
+    let nameField = app.textFields["customNameField"]
+    XCTAssertTrue(nameField.waitForExistence(timeout: 3))
+
+    // Tap Save in the navigation bar toolbar
+    let saveButton = app.navigationBars["New Tracker"].buttons["Save"]
+    XCTAssertTrue(saveButton.waitForExistence(timeout: 3))
+    saveButton.tap()
+
+    // Scroll down to find the error message (it appears below the form fields)
+    app.swipeUp()
+
+    // Verify error message appears (check by text content)
+    let errorText = app.staticTexts["Title must not be empty"]
+    XCTAssertTrue(errorText.waitForExistence(timeout: 5))
+
+    // Verify we're still on the form (not navigated away)
+    XCTAssertTrue(app.navigationBars["New Tracker"].exists)
+  }
+}

--- a/project.yml
+++ b/project.yml
@@ -88,6 +88,22 @@ targets:
     info:
       path: Tests/Info.plist
 
+  RenewedUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    bundleId: com.benniemosher.renewed.ui-tests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.benniemosher.renewed.ui-tests
+        TEST_TARGET_NAME: Renewed
+    sources:
+      - path: Tests/UI
+        createIntermediateGroups: true
+    dependencies:
+      - target: Renewed
+    info:
+      path: Tests/Info.plist
+
 schemes:
   Renewed:
     build:
@@ -101,3 +117,4 @@ schemes:
       targets:
         - name: RenewedTests
           coverage: true
+        - name: RenewedUITests


### PR DESCRIPTION
## Summary
- Add `CardStyle` enum (`.compact`, `.large`, `.square`) to `TrackerCardView`
- Use `@ScaledMetric` for day count font sizes to support Dynamic Type
- Fix dark mode: use `secondarySystemBackground` so cards are visible against pure black
- Adaptive shadow: white glow in dark mode, black shadow in light mode
- Add preview providers for all three variants and Dynamic Type accessibility

## Test plan
- [x] `task test` passes all existing tests (no behavior change to compact variant)
- [x] Verify dark mode cards are visible with proper shadow
- [x] Check Xcode previews for Compact, Large, Square, and Dynamic Type variants

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)