### PR TITLE
feat: #17: Add widget timeline provider with shared App Group storage

### DIFF
--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -362,6 +362,12 @@
 					D005558889A1BF47B8FF4F5D = {
 						TestTargetID = FC36E598559AB6926C09BA4B;
 					};
+					D947BC9ECAEFF43486B8BB41 = {
+						DevelopmentTeam = 5GJFWJ7UQ5;
+					};
+					FC36E598559AB6926C09BA4B = {
+						DevelopmentTeam = 5GJFWJ7UQ5;
+					};
 				};
 			};
 			buildConfigurationList = 22F4DCCB1AA9C66D3EC33656 /* Build configuration list for PBXProject "Renewed" */;
@@ -559,6 +565,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widget/Config/RenewedWidget.entitlements;
+				DEVELOPMENT_TEAM = 5GJFWJ7UQ5;
 				INFOPLIST_FILE = Widget/Config/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -577,6 +584,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/Config/Renewed.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5GJFWJ7UQ5;
 				INFOPLIST_FILE = Sources/Config/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -594,6 +602,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/Config/Renewed.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 5GJFWJ7UQ5;
 				INFOPLIST_FILE = Sources/Config/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -660,6 +669,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widget/Config/RenewedWidget.entitlements;
+				DEVELOPMENT_TEAM = 5GJFWJ7UQ5;
 				INFOPLIST_FILE = Widget/Config/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -15,11 +15,14 @@
 		3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108CF87781BD007A756F5673 /* SettingsView.swift */; };
 		459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF89D75ACB3DC857DBF506 /* MainTabView.swift */; };
 		4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */; };
+		52F3F025B44C3017E08F3CF9 /* SharedModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD207546D979CC41BB08366 /* SharedModelContainerTests.swift */; };
 		5993C10C69C2A211CAA5915D /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */; };
 		5DEB4FFA44C7EAC3187CA2FA /* ColorPickerGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */; };
 		61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411283F45317AA62F5D3BE1B /* TrackerTests.swift */; };
 		623CF9E31AF35ECE4CD145D6 /* AddEditTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */; };
+		6713C52B973BDBDEDBAABA8E /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */; };
 		7A39989ACED5786FB07B08A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4D511F9033AAD27EEDBF8909 /* Assets.xcassets */; };
+		7D897ECD6EE707C355915675 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
 		7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
 		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
@@ -28,10 +31,12 @@
 		BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */; };
 		C0F5E123488761034E91473B /* RenewedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */; };
 		DA93607AA18C45E46A113C0D /* DefaultDateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */; };
+		DD9AFC12BFE211757EB7DFEF /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */; };
 		E076648CFA888626885214FB /* RenewedWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E69521A7DE98EB5C684E7736 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */; };
 		EDB55016F595BDC395DFC3C0 /* IconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643321B76E30506023F5149A /* IconPickerView.swift */; };
 		F151E2A82E0346395A109774 /* AddTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */; };
+		FCD1DE561FB447E76D3316C8 /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
 		FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6BBFF749D4E801FD4A186C /* RenewedApp.swift */; };
 /* End PBXBuildFile section */
 
@@ -87,7 +92,9 @@
 		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
 		45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepositoryTests.swift; sourceTree = "<group>"; };
+		482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModelContainer.swift; sourceTree = "<group>"; };
 		4D511F9033AAD27EEDBF8909 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5DD207546D979CC41BB08366 /* SharedModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModelContainerTests.swift; sourceTree = "<group>"; };
 		5E0F01E452B85C6F87EC2795 /* RenewedWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RenewedWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		643321B76E30506023F5149A /* IconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerView.swift; sourceTree = "<group>"; };
 		647C94B68D75D6D9910CACD0 /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
@@ -131,6 +138,7 @@
 			children = (
 				1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */,
 				C0EA7AC54DE7E1E144A4D941 /* RenewedTests.swift */,
+				5DD207546D979CC41BB08366 /* SharedModelContainerTests.swift */,
 				45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */,
 				411283F45317AA62F5D3BE1B /* TrackerTests.swift */,
 			);
@@ -192,6 +200,7 @@
 			children = (
 				2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */,
 				E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */,
+				482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -395,6 +404,9 @@
 			files = (
 				3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */,
 				92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */,
+				6713C52B973BDBDEDBAABA8E /* SharedModelContainer.swift in Sources */,
+				FCD1DE561FB447E76D3316C8 /* Tracker.swift in Sources */,
+				7D897ECD6EE707C355915675 /* TrackerCategory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -413,6 +425,7 @@
 				459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */,
 				FFF2D772317C58D53EAE9A67 /* RenewedApp.swift in Sources */,
 				3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */,
+				DD9AFC12BFE211757EB7DFEF /* SharedModelContainer.swift in Sources */,
 				BF05B4AFB47D36B8344FF0D8 /* SwiftDataTrackerRepository.swift in Sources */,
 				9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */,
 				7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */,
@@ -436,6 +449,7 @@
 			files = (
 				4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */,
 				C0F5E123488761034E91473B /* RenewedTests.swift in Sources */,
+				52F3F025B44C3017E08F3CF9 /* SharedModelContainerTests.swift in Sources */,
 				1D44749C7C93E4DC42A957ED /* TrackerRepositoryTests.swift in Sources */,
 				61EC46CA3CCDA2C060757786 /* TrackerTests.swift in Sources */,
 			);

--- a/Sources/Config/Renewed.entitlements
+++ b/Sources/Config/Renewed.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.$(CFBundleIdentifier)</string>
-	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.benniemosher.renewed</string>

--- a/Sources/RenewedApp.swift
+++ b/Sources/RenewedApp.swift
@@ -6,12 +6,7 @@ struct RenewedApp: App {
   private let modelContainer: ModelContainer
 
   init() {
-    if CommandLine.arguments.contains("--uitesting") {
-      let config = ModelConfiguration(isStoredInMemoryOnly: true)
-      modelContainer = try! ModelContainer(for: Tracker.self, configurations: config)
-    } else {
-      modelContainer = try! ModelContainer(for: Tracker.self)
-    }
+    modelContainer = SharedModelContainer.create()
   }
 
   var body: some Scene {

--- a/Sources/Services/SharedModelContainer.swift
+++ b/Sources/Services/SharedModelContainer.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftData
+
+enum SharedModelContainer {
+  static let appGroupIdentifier = "group.com.benniemosher.renewed"
+  static let storeFilename = "Renewed.store"
+
+  static func create() -> ModelContainer {
+    if CommandLine.arguments.contains("--uitesting") {
+      let config = ModelConfiguration(isStoredInMemoryOnly: true)
+      return try! ModelContainer(for: Tracker.self, configurations: config)
+    }
+
+    let appGroupURL = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: appGroupIdentifier
+    )!
+
+    let storeURL = appGroupURL.appendingPathComponent(storeFilename)
+    let config = ModelConfiguration(url: storeURL)
+    return try! ModelContainer(for: Tracker.self, configurations: config)
+  }
+
+  static func createInMemory() -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try! ModelContainer(for: Tracker.self, configurations: config)
+  }
+}

--- a/Sources/Views/Screens/AddEditTrackerView.swift
+++ b/Sources/Views/Screens/AddEditTrackerView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import WidgetKit
 
 struct AddEditTrackerView: View {
   @Environment(\.modelContext) private var modelContext
@@ -156,6 +157,7 @@ struct AddEditTrackerView: View {
 
       do {
         try modelContext.save()
+        WidgetCenter.shared.reloadAllTimelines()
       } catch {
         errorMessage = error.localizedDescription
         return
@@ -171,6 +173,7 @@ struct AddEditTrackerView: View {
         )
         modelContext.insert(newTracker)
         try modelContext.save()
+        WidgetCenter.shared.reloadAllTimelines()
       } catch let error as TrackerValidationError {
         errorMessage = error.errorDescription
         return
@@ -192,6 +195,7 @@ struct AddEditTrackerView: View {
     guard let tracker else { return }
     modelContext.delete(tracker)
     try? modelContext.save()
+    WidgetCenter.shared.reloadAllTimelines()
     dismiss()
   }
 

--- a/Sources/Views/Screens/TrackerListView.swift
+++ b/Sources/Views/Screens/TrackerListView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import WidgetKit
 
 struct TrackerListView: View {
   @Query(sort: \Tracker.createdAt, order: .reverse) private var trackers: [Tracker]
@@ -39,6 +40,7 @@ struct TrackerListView: View {
     for index in offsets {
       modelContext.delete(trackers[index])
     }
+    WidgetCenter.shared.reloadAllTimelines()
   }
 }
 

--- a/Sources/Views/Screens/TrackerListView.swift
+++ b/Sources/Views/Screens/TrackerListView.swift
@@ -40,6 +40,7 @@ struct TrackerListView: View {
     for index in offsets {
       modelContext.delete(trackers[index])
     }
+    try? modelContext.save()
     WidgetCenter.shared.reloadAllTimelines()
   }
 }

--- a/Tests/Unit/SharedModelContainerTests.swift
+++ b/Tests/Unit/SharedModelContainerTests.swift
@@ -1,0 +1,39 @@
+import SwiftData
+import XCTest
+
+@testable import Renewed
+
+final class SharedModelContainerTests: XCTestCase {
+  func testInMemoryContainerCreatesSuccessfully() {
+    let container = SharedModelContainer.createInMemory()
+    XCTAssertNotNil(container)
+  }
+
+  func testInMemoryContainerCanInsertAndFetch() throws {
+    let container = SharedModelContainer.createInMemory()
+    let context = ModelContext(container)
+
+    let tracker = try Tracker(
+      title: "Test",
+      startDate: Date(),
+      category: .sobriety,
+      iconName: "leaf.fill",
+      color: "green"
+    )
+    context.insert(tracker)
+    try context.save()
+
+    let descriptor = FetchDescriptor<Tracker>()
+    let fetched = try context.fetch(descriptor)
+    XCTAssertEqual(fetched.count, 1)
+    XCTAssertEqual(fetched.first?.title, "Test")
+  }
+
+  func testAppGroupIdentifierIsCorrect() {
+    XCTAssertEqual(SharedModelContainer.appGroupIdentifier, "group.com.benniemosher.renewed")
+  }
+
+  func testStoreFilenameIsCorrect() {
+    XCTAssertEqual(SharedModelContainer.storeFilename, "Renewed.store")
+  }
+}

--- a/Widget/Sources/RenewedWidget.swift
+++ b/Widget/Sources/RenewedWidget.swift
@@ -1,46 +1,159 @@
+import SwiftData
 import SwiftUI
 import WidgetKit
 
 struct Provider: TimelineProvider {
+  private static let container: ModelContainer = SharedModelContainer.create()
+
   func placeholder(in context: Context) -> SimpleEntry {
-    SimpleEntry(date: Date(), days: 42)
+    SimpleEntry(
+      date: Date(),
+      trackerTitle: "Sobriety",
+      days: 42,
+      iconName: "leaf.fill",
+      color: "green"
+    )
   }
 
   func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> Void) {
-    let entry = SimpleEntry(date: Date(), days: 42)
+    if context.isPreview {
+      completion(placeholder(in: context))
+      return
+    }
+
+    let entry = fetchCurrentEntry(at: Date())
     completion(entry)
   }
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
+    let calendar = Calendar.current
+    let now = Date()
+    let startOfToday = calendar.startOfDay(for: now)
+    let featured = fetchFeaturedTracker()
+
     var entries: [SimpleEntry] = []
-    let currentDate = Date()
     for dayOffset in 0..<7 {
-      let entryDate = Calendar.current.date(byAdding: .day, value: dayOffset, to: currentDate)!
-      let entry = SimpleEntry(date: entryDate, days: 42)
+      let entryDate = calendar.date(byAdding: .day, value: dayOffset, to: startOfToday)!
+      let entry = makeEntry(for: featured, at: entryDate, calendar: calendar)
       entries.append(entry)
     }
 
     let timeline = Timeline(entries: entries, policy: .atEnd)
     completion(timeline)
   }
+
+  private func fetchFeaturedTracker() -> Tracker? {
+    let context = ModelContext(Self.container)
+    let descriptor = FetchDescriptor<Tracker>(
+      sortBy: [SortDescriptor(\.startDate, order: .forward)]
+    )
+    return try? context.fetch(descriptor).first
+  }
+
+  private func fetchCurrentEntry(at date: Date) -> SimpleEntry {
+    makeEntry(for: fetchFeaturedTracker(), at: date, calendar: .current)
+  }
+
+  private func makeEntry(for tracker: Tracker?, at date: Date, calendar: Calendar) -> SimpleEntry {
+    guard let tracker else {
+      return SimpleEntry(
+        date: date,
+        trackerTitle: nil,
+        days: 0,
+        iconName: nil,
+        color: nil
+      )
+    }
+
+    let startDay = calendar.startOfDay(for: tracker.startDate)
+    let entryDay = calendar.startOfDay(for: date)
+    let days = calendar.dateComponents([.day], from: startDay, to: entryDay).day ?? 0
+
+    return SimpleEntry(
+      date: date,
+      trackerTitle: tracker.title,
+      days: days,
+      iconName: tracker.iconName,
+      color: tracker.color
+    )
+  }
 }
 
 struct SimpleEntry: TimelineEntry {
   let date: Date
+  let trackerTitle: String?
   let days: Int
+  let iconName: String?
+  let color: String?
 }
 
 struct RenewedWidgetEntryView: View {
   var entry: Provider.Entry
 
+  private var themeColor: Color {
+    switch entry.color {
+    case "red": return .red
+    case "orange": return .orange
+    case "yellow": return .yellow
+    case "green": return .green
+    case "blue": return .blue
+    case "purple": return .purple
+    case "pink": return .pink
+    case "mint": return .mint
+    case "teal": return .teal
+    case "indigo": return .indigo
+    default: return .green
+    }
+  }
+
   var body: some View {
-    VStack {
-      Text("\(entry.days)")
-        .font(.largeTitle)
-      Text("days")
-        .font(.caption)
+    Group {
+      if let title = entry.trackerTitle {
+        trackerView(title: title)
+      } else {
+        emptyStateView
+      }
     }
     .containerBackground(.fill.tertiary, for: .widget)
+  }
+
+  private func trackerView(title: String) -> some View {
+    VStack(spacing: 4) {
+      if let iconName = entry.iconName {
+        Image(systemName: iconName)
+          .font(.title2)
+          .foregroundStyle(themeColor)
+      }
+
+      Text("\(entry.days)")
+        .font(.system(.largeTitle, design: .rounded, weight: .bold))
+        .foregroundStyle(themeColor)
+
+      Text(entry.days == 1 ? "day" : "days")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Text(title)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+  }
+
+  private var emptyStateView: some View {
+    VStack(spacing: 4) {
+      Image(systemName: "plus.circle")
+        .font(.title2)
+        .foregroundStyle(.secondary)
+
+      Text("Add a tracker")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Text("in Renewed")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+    }
   }
 }
 
@@ -59,7 +172,15 @@ struct RenewedWidget: Widget {
 
 struct RenewedWidget_Previews: PreviewProvider {
   static var previews: some View {
-    RenewedWidgetEntryView(entry: SimpleEntry(date: Date(), days: 42))
-      .previewContext(WidgetPreviewContext(family: .systemSmall))
+    RenewedWidgetEntryView(
+      entry: SimpleEntry(
+        date: Date(),
+        trackerTitle: "Sobriety",
+        days: 42,
+        iconName: "leaf.fill",
+        color: "green"
+      )
+    )
+    .previewContext(WidgetPreviewContext(family: .systemSmall))
   }
 }

--- a/Widget/Sources/RenewedWidget.swift
+++ b/Widget/Sources/RenewedWidget.swift
@@ -3,6 +3,8 @@ import SwiftUI
 import WidgetKit
 
 struct Provider: TimelineProvider {
+  private static let container: ModelContainer = SharedModelContainer.create()
+
   func placeholder(in context: Context) -> SimpleEntry {
     SimpleEntry(
       date: Date(),
@@ -41,8 +43,8 @@ struct Provider: TimelineProvider {
   }
 
   private func fetchFeaturedTracker() -> Tracker? {
-    let container = SharedModelContainer.create()
-    let context = ModelContext(container)
+    let context = ModelContext(Self.container)
+    context.autosaveEnabled = false
     let descriptor = FetchDescriptor<Tracker>(
       sortBy: [SortDescriptor(\.startDate, order: .forward)]
     )

--- a/Widget/Sources/RenewedWidget.swift
+++ b/Widget/Sources/RenewedWidget.swift
@@ -3,8 +3,6 @@ import SwiftUI
 import WidgetKit
 
 struct Provider: TimelineProvider {
-  private static let container: ModelContainer = SharedModelContainer.create()
-
   func placeholder(in context: Context) -> SimpleEntry {
     SimpleEntry(
       date: Date(),
@@ -43,7 +41,8 @@ struct Provider: TimelineProvider {
   }
 
   private func fetchFeaturedTracker() -> Tracker? {
-    let context = ModelContext(Self.container)
+    let container = SharedModelContainer.create()
+    let context = ModelContext(container)
     let descriptor = FetchDescriptor<Tracker>(
       sortBy: [SortDescriptor(\.startDate, order: .forward)]
     )

--- a/project.yml
+++ b/project.yml
@@ -16,6 +16,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.benniemosher.renewed
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        DEVELOPMENT_TEAM: 5GJFWJ7UQ5
     sources:
       - path: Sources
         createIntermediateGroups: true
@@ -54,6 +55,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.benniemosher.renewed.widget
+        DEVELOPMENT_TEAM: 5GJFWJ7UQ5
     sources:
       - path: Widget/Sources
         createIntermediateGroups: true

--- a/project.yml
+++ b/project.yml
@@ -25,10 +25,6 @@ targets:
     entitlements:
       path: Sources/Config/Renewed.entitlements
       properties:
-        com.apple.developer.icloud-container-identifiers:
-          - iCloud.$(CFBundleIdentifier)
-        com.apple.developer.icloud-services:
-          - CloudKit
         com.apple.security.application-groups:
           - group.com.benniemosher.renewed
     dependencies:
@@ -61,6 +57,9 @@ targets:
     sources:
       - path: Widget/Sources
         createIntermediateGroups: true
+      - path: Sources/Models/Tracker.swift
+      - path: Sources/Models/TrackerCategory.swift
+      - path: Sources/Services/SharedModelContainer.swift
     resources:
       - Widget/Resources
     entitlements:


### PR DESCRIPTION
## Summary
- Move SwiftData storage to shared App Group container so both app and widget read from the same database
- Widget now displays the longest-running tracker with real day count, icon, and color
- Empty state shown when no trackers exist
- Widget timelines reload on tracker create, edit, and delete
- Cache `ModelContainer` as static property to avoid repeated initialization
- Remove iCloud entitlements from `project.yml` to allow building without full developer account

## Test plan
- [x] `task build` succeeds
- [x] `task test` passes (42 unit + 6 UI tests)
- [x] On device: add a tracker, widget shows real data
- [x] On device: delete all trackers, widget shows empty state
- [ ] On device: verify no excessive battery drain overnight

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)