### PR TITLE
feat: #19: Add medium widget showing two trackers side by side

### DIFF
--- a/Renewed.xcodeproj/project.pbxproj
+++ b/Renewed.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		1BFD5F0F67F3DBB30FBBF4D5 /* SelectTrackerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCEAEF7CFDEFB25FA851666 /* SelectTrackerIntent.swift */; };
 		1D44749C7C93E4DC42A957ED /* TrackerRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */; };
 		24194D0CEC21650371DA3251 /* TrackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931C054D6732FD0D07615293 /* TrackerUITests.swift */; };
+		2C18864EDF83444DDCA68512 /* MediumWidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B6410E9D696044D85048DB /* MediumWidgetEntryView.swift */; };
 		3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */; };
 		3943CE0ECED784B4C44E23DB /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C94B68D75D6D9910CACD0 /* LaunchScreenView.swift */; };
 		396CEE9B353BD344DC23C2DD /* DateCalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */; };
 		3ECE9CC7E2FB9BBB255E0384 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108CF87781BD007A756F5673 /* SettingsView.swift */; };
+		41D1E159BA96A7F33C77F244 /* MediumWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15B58B719A060090B4852DC /* MediumWidget.swift */; };
 		459A02CCF77B6B8A5004E41B /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF89D75ACB3DC857DBF506 /* MainTabView.swift */; };
 		4D1D42330A88C584717EFA94 /* DateCalculationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E18C5046C87B8585D9F610E /* DateCalculationServiceTests.swift */; };
 		52F3F025B44C3017E08F3CF9 /* SharedModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD207546D979CC41BB08366 /* SharedModelContainerTests.swift */; };
@@ -23,11 +25,14 @@
 		623CF9E31AF35ECE4CD145D6 /* AddEditTrackerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */; };
 		6579077FC5370C517F6DE924 /* ConfigurableProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1924A319AA801B46216FE /* ConfigurableProvider.swift */; };
 		6713C52B973BDBDEDBAABA8E /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */; };
+		6DDD1367F7293F61662386DB /* MediumEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C5EE88626AD10864F48E0F /* MediumEntry.swift */; };
+		715B7D4A228E9D5061560971 /* MediumWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FE570F18C4E1DB0892C5A1 /* MediumWidgetProvider.swift */; };
 		7A39989ACED5786FB07B08A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4D511F9033AAD27EEDBF8909 /* Assets.xcassets */; };
 		7D897ECD6EE707C355915675 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
 		7FD4B5D0EC88FCB74D12069E /* TrackerCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */; };
 		92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */; };
 		9502FF7139ECD56F7D611A0C /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE1C3C24BBDE97583AB65B /* Tracker.swift */; };
+		A2E8343934C03318C265E99A /* SelectTwoTrackersIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA983E1716158062F136559F /* SelectTwoTrackersIntent.swift */; };
 		A7553B50942C320AAD5F3DD3 /* TrackerCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4771B7CA1D303F08C21C5 /* TrackerCategory.swift */; };
 		B15C7257E8E078064EAEC121 /* TrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2A3306704DA73C96729906 /* TrackerRepository.swift */; };
 		B46220599A153E67AEFF78D1 /* TrackerQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB57275A42B9DA5DEBB74CD /* TrackerQuery.swift */; };
@@ -91,13 +96,16 @@
 		24CEC173CB0AA0445A5AF25E /* TrackerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerListView.swift; sourceTree = "<group>"; };
 		2690A5CDF31F27512A2C6D36 /* AddTrackerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackerView.swift; sourceTree = "<group>"; };
 		296AFBB6A426ED33B0EE5AF9 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		29C5EE88626AD10864F48E0F /* MediumEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediumEntry.swift; sourceTree = "<group>"; };
 		2B6A82AC5A1A0C88B58B7512 /* DateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCalculationService.swift; sourceTree = "<group>"; };
 		2D895DA05EBA74C1E3BC98A0 /* TrackerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerEntity.swift; sourceTree = "<group>"; };
 		311534E27C5F733FB5B97D1F /* AddEditTrackerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditTrackerView.swift; sourceTree = "<group>"; };
 		411283F45317AA62F5D3BE1B /* TrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerTests.swift; sourceTree = "<group>"; };
 		442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewedWidgetBundle.swift; sourceTree = "<group>"; };
+		44B6410E9D696044D85048DB /* MediumWidgetEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediumWidgetEntryView.swift; sourceTree = "<group>"; };
 		45CEFEB32AD9EBA9F1A06DF3 /* TrackerRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepositoryTests.swift; sourceTree = "<group>"; };
 		482511E44A2D2EF462667BE0 /* SharedModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModelContainer.swift; sourceTree = "<group>"; };
+		48FE570F18C4E1DB0892C5A1 /* MediumWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediumWidgetProvider.swift; sourceTree = "<group>"; };
 		4AC1924A319AA801B46216FE /* ConfigurableProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableProvider.swift; sourceTree = "<group>"; };
 		4D511F9033AAD27EEDBF8909 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5DD207546D979CC41BB08366 /* SharedModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModelContainerTests.swift; sourceTree = "<group>"; };
@@ -117,8 +125,10 @@
 		D9612FBD483C8A8DDC467470 /* TrackerCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCardView.swift; sourceTree = "<group>"; };
 		DC58BB83E261500351F9BDEA /* SwiftDataTrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTrackerRepository.swift; sourceTree = "<group>"; };
 		DF66FA312B219F1922D34C64 /* ColorPickerGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerGridView.swift; sourceTree = "<group>"; };
+		E15B58B719A060090B4852DC /* MediumWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediumWidget.swift; sourceTree = "<group>"; };
 		E7C11D23A5541A470CA8E33D /* DefaultDateCalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDateCalculationService.swift; sourceTree = "<group>"; };
 		ECCEAEF7CFDEFB25FA851666 /* SelectTrackerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTrackerIntent.swift; sourceTree = "<group>"; };
+		FA983E1716158062F136559F /* SelectTwoTrackersIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTwoTrackersIntent.swift; sourceTree = "<group>"; };
 		FE2A3306704DA73C96729906 /* TrackerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -198,9 +208,14 @@
 			isa = PBXGroup;
 			children = (
 				4AC1924A319AA801B46216FE /* ConfigurableProvider.swift */,
+				29C5EE88626AD10864F48E0F /* MediumEntry.swift */,
+				E15B58B719A060090B4852DC /* MediumWidget.swift */,
+				44B6410E9D696044D85048DB /* MediumWidgetEntryView.swift */,
+				48FE570F18C4E1DB0892C5A1 /* MediumWidgetProvider.swift */,
 				6AFE12B4D82058E2D4E6F958 /* RenewedWidget.swift */,
 				442C61D349A29E726DAF4E10 /* RenewedWidgetBundle.swift */,
 				ECCEAEF7CFDEFB25FA851666 /* SelectTrackerIntent.swift */,
+				FA983E1716158062F136559F /* SelectTwoTrackersIntent.swift */,
 				2D895DA05EBA74C1E3BC98A0 /* TrackerEntity.swift */,
 				6AB57275A42B9DA5DEBB74CD /* TrackerQuery.swift */,
 			);
@@ -421,9 +436,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6579077FC5370C517F6DE924 /* ConfigurableProvider.swift in Sources */,
+				6DDD1367F7293F61662386DB /* MediumEntry.swift in Sources */,
+				41D1E159BA96A7F33C77F244 /* MediumWidget.swift in Sources */,
+				2C18864EDF83444DDCA68512 /* MediumWidgetEntryView.swift in Sources */,
+				715B7D4A228E9D5061560971 /* MediumWidgetProvider.swift in Sources */,
 				3445177327DBEE420EAC9D71 /* RenewedWidget.swift in Sources */,
 				92408B3BD16304646E52F30C /* RenewedWidgetBundle.swift in Sources */,
 				1BFD5F0F67F3DBB30FBBF4D5 /* SelectTrackerIntent.swift in Sources */,
+				A2E8343934C03318C265E99A /* SelectTwoTrackersIntent.swift in Sources */,
 				6713C52B973BDBDEDBAABA8E /* SharedModelContainer.swift in Sources */,
 				FCD1DE561FB447E76D3316C8 /* Tracker.swift in Sources */,
 				7D897ECD6EE707C355915675 /* TrackerCategory.swift in Sources */,

--- a/Widget/Sources/MediumEntry.swift
+++ b/Widget/Sources/MediumEntry.swift
@@ -1,0 +1,15 @@
+import WidgetKit
+
+struct TrackerData {
+  let id: String
+  let title: String
+  let days: Int
+  let iconName: String
+  let color: String
+}
+
+struct MediumEntry: TimelineEntry {
+  let date: Date
+  let trackers: [TrackerData]
+  let totalTrackerCount: Int
+}

--- a/Widget/Sources/MediumWidget.swift
+++ b/Widget/Sources/MediumWidget.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import WidgetKit
+
+struct MediumWidget: Widget {
+  let kind: String = "MediumWidget"
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: kind, intent: SelectTwoTrackersIntent.self, provider: MediumWidgetProvider()
+    ) { entry in
+      MediumWidgetEntryView(entry: entry)
+    }
+    .configurationDisplayName("Renewed (Dual)")
+    .description("Track two journeys side by side.")
+    .supportedFamilies([.systemMedium])
+  }
+}
+
+struct MediumWidget_Previews: PreviewProvider {
+  static var previews: some View {
+    MediumWidgetEntryView(
+      entry: MediumEntry(
+        date: Date(),
+        trackers: [
+          TrackerData(
+            id: "1", title: "Sobriety", days: 42, iconName: "leaf.fill", color: "green"),
+          TrackerData(
+            id: "2", title: "Meditation", days: 15, iconName: "brain.head.profile",
+            color: "purple"),
+        ],
+        totalTrackerCount: 5
+      )
+    )
+    .previewContext(WidgetPreviewContext(family: .systemMedium))
+  }
+}

--- a/Widget/Sources/MediumWidgetEntryView.swift
+++ b/Widget/Sources/MediumWidgetEntryView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import WidgetKit
+
+struct MediumWidgetEntryView: View {
+  var entry: MediumEntry
+
+  var body: some View {
+    Group {
+      if entry.trackers.isEmpty {
+        emptyStateView
+      } else {
+        trackerContentView
+      }
+    }
+    .containerBackground(.fill.tertiary, for: .widget)
+  }
+
+  private var trackerContentView: some View {
+    VStack(spacing: 4) {
+      HStack(spacing: 12) {
+        trackerCard(for: entry.trackers[0])
+
+        if entry.trackers.count > 1 {
+          trackerCard(for: entry.trackers[1])
+        } else {
+          emptySlotView
+        }
+      }
+
+      if entry.totalTrackerCount > entry.trackers.count {
+        let remaining = entry.totalTrackerCount - entry.trackers.count
+        Text("+\(remaining) more")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  private func trackerCard(for tracker: TrackerData) -> some View {
+    VStack(spacing: 4) {
+      Image(systemName: tracker.iconName)
+        .font(.title2)
+        .foregroundStyle(color(for: tracker.color))
+
+      Text("\(tracker.days)")
+        .font(.system(.title, design: .rounded, weight: .bold))
+        .foregroundStyle(color(for: tracker.color))
+
+      Text(tracker.days == 1 ? "day" : "days")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Text(tracker.title)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private var emptySlotView: some View {
+    VStack(spacing: 4) {
+      Image(systemName: "plus.circle.dashed")
+        .font(.title2)
+        .foregroundStyle(.quaternary)
+
+      Text("Add another")
+        .font(.caption)
+        .foregroundStyle(.quaternary)
+
+      Text("tracker")
+        .font(.caption2)
+        .foregroundStyle(.quaternary)
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private var emptyStateView: some View {
+    VStack(spacing: 4) {
+      Image(systemName: "plus.circle")
+        .font(.title2)
+        .foregroundStyle(.secondary)
+
+      Text("Add a tracker")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Text("in Renewed")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+    }
+  }
+
+  private func color(for name: String) -> Color {
+    switch name {
+    case "red": return .red
+    case "orange": return .orange
+    case "yellow": return .yellow
+    case "green": return .green
+    case "blue": return .blue
+    case "purple": return .purple
+    case "pink": return .pink
+    case "mint": return .mint
+    case "teal": return .teal
+    case "indigo": return .indigo
+    default: return .green
+    }
+  }
+}

--- a/Widget/Sources/MediumWidgetProvider.swift
+++ b/Widget/Sources/MediumWidgetProvider.swift
@@ -1,0 +1,118 @@
+import SwiftData
+import WidgetKit
+
+struct MediumWidgetProvider: AppIntentTimelineProvider {
+  private static let container: ModelContainer = SharedModelContainer.create()
+
+  func placeholder(in context: Context) -> MediumEntry {
+    MediumEntry(
+      date: Date(),
+      trackers: [
+        TrackerData(id: "1", title: "Sobriety", days: 42, iconName: "leaf.fill", color: "green"),
+        TrackerData(
+          id: "2", title: "Meditation", days: 15, iconName: "brain.head.profile", color: "purple"),
+      ],
+      totalTrackerCount: 2
+    )
+  }
+
+  func snapshot(for configuration: SelectTwoTrackersIntent, in context: Context) async
+    -> MediumEntry
+  {
+    if context.isPreview {
+      return placeholder(in: context)
+    }
+
+    return fetchEntry(for: configuration, at: Date())
+  }
+
+  func timeline(
+    for configuration: SelectTwoTrackersIntent, in context: Context
+  ) async -> Timeline<MediumEntry> {
+    let calendar = Calendar.current
+    let startOfToday = calendar.startOfDay(for: Date())
+    let trackers = fetchTrackers(for: configuration)
+    let totalCount = fetchAllTrackerCount()
+
+    var entries: [MediumEntry] = []
+    for dayOffset in 0..<7 {
+      let entryDate = calendar.date(byAdding: .day, value: dayOffset, to: startOfToday)!
+      let entry = makeEntry(
+        for: trackers, at: entryDate, totalCount: totalCount, calendar: calendar)
+      entries.append(entry)
+    }
+
+    return Timeline(entries: entries, policy: .atEnd)
+  }
+
+  private func fetchTrackers(for configuration: SelectTwoTrackersIntent) -> [Tracker] {
+    let context = ModelContext(Self.container)
+    context.autosaveEnabled = false
+
+    let hasUserSelection = configuration.tracker1 != nil || configuration.tracker2 != nil
+
+    // No user selection — show 2 newest trackers as default
+    if !hasUserSelection {
+      var descriptor = FetchDescriptor<Tracker>(
+        sortBy: [SortDescriptor(\.startDate, order: .reverse)]
+      )
+      descriptor.fetchLimit = 2
+      return (try? context.fetch(descriptor)) ?? []
+    }
+
+    // User has configured at least one picker — resolve selections, skip duplicates
+    var resolved: [Tracker] = []
+    var resolvedIDs: Set<UUID> = []
+
+    for selectedID in [configuration.tracker1?.id, configuration.tracker2?.id] {
+      guard let idString = selectedID, let uuid = UUID(uuidString: idString) else { continue }
+      guard !resolvedIDs.contains(uuid) else { continue }
+      let predicate = #Predicate<Tracker> { $0.id == uuid }
+      var descriptor = FetchDescriptor<Tracker>(predicate: predicate)
+      descriptor.fetchLimit = 1
+      if let tracker = try? context.fetch(descriptor).first {
+        resolved.append(tracker)
+        resolvedIDs.insert(tracker.id)
+      }
+    }
+
+    return resolved
+  }
+
+  private func fetchAllTrackerCount() -> Int {
+    let context = ModelContext(Self.container)
+    context.autosaveEnabled = false
+    let descriptor = FetchDescriptor<Tracker>()
+    return (try? context.fetchCount(descriptor)) ?? 0
+  }
+
+  private func fetchEntry(for configuration: SelectTwoTrackersIntent, at date: Date) -> MediumEntry
+  {
+    let trackers = fetchTrackers(for: configuration)
+    let totalCount = fetchAllTrackerCount()
+    return makeEntry(for: trackers, at: date, totalCount: totalCount, calendar: .current)
+  }
+
+  private func makeEntry(
+    for trackers: [Tracker], at date: Date, totalCount: Int, calendar: Calendar
+  ) -> MediumEntry {
+    let trackerData = trackers.map { tracker -> TrackerData in
+      let startDay = calendar.startOfDay(for: tracker.startDate)
+      let entryDay = calendar.startOfDay(for: date)
+      let days = calendar.dateComponents([.day], from: startDay, to: entryDay).day ?? 0
+      return TrackerData(
+        id: tracker.id.uuidString,
+        title: tracker.title,
+        days: days,
+        iconName: tracker.iconName,
+        color: tracker.color
+      )
+    }
+
+    return MediumEntry(
+      date: date,
+      trackers: trackerData,
+      totalTrackerCount: totalCount
+    )
+  }
+}

--- a/Widget/Sources/RenewedWidget.swift
+++ b/Widget/Sources/RenewedWidget.swift
@@ -91,7 +91,7 @@ struct RenewedWidget: Widget {
     }
     .configurationDisplayName("Renewed")
     .description("Track your journey.")
-    .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    .supportedFamilies([.systemSmall])
   }
 }
 

--- a/Widget/Sources/RenewedWidgetBundle.swift
+++ b/Widget/Sources/RenewedWidgetBundle.swift
@@ -5,5 +5,6 @@ import WidgetKit
 struct RenewedWidgetBundle: WidgetBundle {
   var body: some Widget {
     RenewedWidget()
+    MediumWidget()
   }
 }

--- a/Widget/Sources/SelectTwoTrackersIntent.swift
+++ b/Widget/Sources/SelectTwoTrackersIntent.swift
@@ -1,0 +1,13 @@
+import AppIntents
+import WidgetKit
+
+struct SelectTwoTrackersIntent: WidgetConfigurationIntent {
+  static var title: LocalizedStringResource = "Select Two Trackers"
+  static var description: IntentDescription = "Choose two trackers to display side by side."
+
+  @Parameter(title: "First Tracker")
+  var tracker1: TrackerEntity?
+
+  @Parameter(title: "Second Tracker")
+  var tracker2: TrackerEntity?
+}

--- a/Widget/Sources/TrackerQuery.swift
+++ b/Widget/Sources/TrackerQuery.swift
@@ -17,10 +17,6 @@ struct TrackerQuery: EntityQuery {
       .map { TrackerEntity(id: $0.id.uuidString, title: $0.title, iconName: $0.iconName) }
   }
 
-  func defaultResult() -> TrackerEntity? {
-    suggestedEntities().first
-  }
-
   func suggestedEntities() -> [TrackerEntity] {
     let context = ModelContext(Self.container)
     context.autosaveEnabled = false


### PR DESCRIPTION
## Summary
- Add medium-sized widget ("Renewed (Dual)") showing up to 2 trackers side by side
- New `SelectTwoTrackersIntent` with two tracker picker parameters
- Dedicated `MediumWidgetProvider` with dedup logic and fallback to 2 newest trackers
- "+N more" indicator when total trackers exceed displayed count
- Restrict existing small widget to `.systemSmall` only
- Remove `defaultResult()` from `TrackerQuery` to avoid both pickers defaulting to same tracker

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)